### PR TITLE
Add PlayMode test harness (phase 0)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,19 @@ jobs:
           key: Library-${{ matrix.testMode }}-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
           restore-keys: Library-${{ matrix.testMode }}-
 
+      # Addressables keeps its play mode catalog inside Library, so the restore above brings back whatever
+      # state the previous run left there. That state is not self-repairing: run 8 restored the Library run 6
+      # saved and then failed 7 of the 8 AddressablesTests on
+      #   Invalid path in TextDataProvider : 'Library/com.unity.addressables/aa/Linux/settings.json'
+      #   -> Addressables - Unable to load runtime data -> No Location found for Key=<fixture guid>
+      # What is certain is that the catalog is absent at read time and nothing rebuilds it, and that run 6 -
+      # the last green one, and the run that saved this cache - restored no Library at all. The likely
+      # mechanism is that the file is cleaned when play mode exits, so the cache carries the bookkeeping that
+      # says "already built" without the file it points at. Either way, dropping the subtree puts Addressables
+      # back in the cold state it does build a catalog from; it is a no-op on a cold Library.
+      - name: Drop the cached Addressables play mode catalog
+        run: rm -rf Library/com.unity.addressables
+
       # The stock unityci/editor image ships no audio libraries, so FMOD finds no output device
       # and falls back to a non-realtime null sink pumped by the frame loop - measured at 747.94x
       # wall time, which makes every PlayMode timing test a coin flip. This image adds a

--- a/Assets/Tests/Runtime/SpectrumAnalyzerTests.cs
+++ b/Assets/Tests/Runtime/SpectrumAnalyzerTests.cs
@@ -17,7 +17,10 @@ namespace Ami.BroAudio.Tests
     /// floor (<c>0f.ToDecibel()</c> == <see cref="AudioConstant.MinDecibelVolume"/>), so a band pinned above
     /// the floor must fall and a band pinned below it must rise, at a rate the inspector fields control and
     /// nothing else. <see cref="SpectrumAnalyzer.Band.SetVolume"/> is public, so pinning a band is done
-    /// through the component's own API rather than by reflection.
+    /// through the component's own API rather than by reflection. That holds for any band wide enough to
+    /// meter over - residual noise from the mixer is orders of magnitude below <c>MinVolume</c> and clamps
+    /// away - but not for the divide-by-zero band below, whose target is decided by whether one bin is
+    /// exactly zero or merely near it, so that one test asserts on both outcomes.
     /// </para>
     /// <para>
     /// One test plays a real tone end to end. It is the only one whose result depends on the engine actually
@@ -395,11 +398,15 @@ namespace Ami.BroAudio.Tests
 
         #region Band ranges
         // TEST_FINDINGS #39. A band whose frequency window is narrower than one FFT bin has start == end, so
-        // RangeInt.length is 0, and RMS/Average divide the summed magnitude by it. The resulting NaN fails
-        // every comparison in the ballistics block, which leaves the band subtracting a step forever: its
-        // decibel value sinks below a floor it is supposed to rest on, while Amplitube clamps and hides it.
+        // RangeInt.length is 0, and RMS/Average divide the summed magnitude by it. Which way that breaks is
+        // decided by the one bin the band covers, and the test may not assume either: an exactly-zero bin
+        // gives 0/0 = NaN, which loses every comparison in the ballistics block and leaves the band
+        // subtracting a step forever, while a bin holding any energy at all gives x/0 = +Infinity, which
+        // ClampNormalize pins to MaxVolume and the band climbs to the ceiling instead. Both ends are wrong in
+        // the same way - the band stops reporting the signal - so the assertion is that it leaves the floor,
+        // and then that whichever end it ran to is the end the ballistics block makes it run to.
         [UnityTest]
-        public IEnumerator Update_WithABandNarrowerThanOneFftBin_SinksBelowTheFloorUnderRmsButHoldsUnderPeak()
+        public IEnumerator Update_WithABandNarrowerThanOneFftBin_LeavesTheFloorUnderRmsButHoldsUnderPeak()
         {
             yield return RequireRealtimeAudioClock();
             IAudioPlayer player = PlaySilence();
@@ -417,17 +424,37 @@ namespace Ami.BroAudio.Tests
             rms.SetSource(player);
             peak.SetSource(player);
 
-            yield return WaitUntilOrTimeout(() => rms.Bands[1].DecibelVolume < AudioConstant.MinDecibelVolume - 10f,
-                "the RMS metering of a sub-bin band to sink well below the decibel floor", 3f);
+            // 10dB is far enough out that no ballistics ramp can be sitting there by accident, and both
+            // runaways cover it in well under a second: the decay step is 20dB/1500ms, the attack 20dB/100ms.
+            const float FloorDistance = 10f;
+            yield return WaitUntilOrTimeout(
+                () => Mathf.Abs(rms.Bands[1].DecibelVolume - AudioConstant.MinDecibelVolume) > FloorDistance,
+                "the RMS metering of a sub-bin band to leave the decibel floor in either direction", 3f);
 
-            Assert.AreEqual(AudioConstant.MinVolume, rms.Bands[1].Amplitube, 1e-6f,
-                "Amplitube clamps at the floor, so nothing bound to it can see the value running away underneath.");
-            Assert.GreaterOrEqual(rms.Bands[0].DecibelVolume, AudioConstant.MinDecibelVolume - 1f,
+            if (rms.Bands[1].DecibelVolume < AudioConstant.MinDecibelVolume)
+            {
+                // 0/0: the NaN target fails even "close enough, snap to it", so the band never stops falling.
+                Assert.AreEqual(AudioConstant.MinVolume, rms.Bands[1].Amplitube, 1e-6f,
+                    "Amplitube clamps at the floor, so nothing bound to it can see the value running away underneath.");
+            }
+            else
+            {
+                // x/0: ClampNormalize turns the +Infinity target into MaxVolume, so the band settles on the
+                // ceiling and reports full scale for a signal that is not there.
+                // The ballistics block snaps to the target once one step covers what is left, so the climb
+                // ends on MaxDecibelVolume exactly rather than approaching it.
+                yield return WaitUntilOrTimeout(
+                    () => rms.Bands[1].DecibelVolume >= AudioConstant.MaxDecibelVolume,
+                    "the same band to finish its climb to the ceiling", 3f);
+
+                Assert.AreEqual(AudioConstant.MaxVolume, rms.Bands[1].Amplitube, 1e-4f,
+                    "Amplitube clamps at the ceiling, so a meter bound to it reads full scale on silence.");
+            }
+
+            Assert.AreEqual(AudioConstant.MinDecibelVolume, rms.Bands[0].DecibelVolume, DecibelTolerance,
                 "The wide band of the same analyzer holds - this is the range width, not the metering mode.");
-            Assert.GreaterOrEqual(peak.Bands[1].DecibelVolume, AudioConstant.MinDecibelVolume - 1f,
+            Assert.AreEqual(AudioConstant.MinDecibelVolume, peak.Bands[1].DecibelVolume, DecibelTolerance,
                 "Peak metering never divides by the range length, so the same band rests on the floor.");
-            Assert.LessOrEqual(peak.Bands[1].DecibelVolume, AudioConstant.MinDecibelVolume + DecibelTolerance,
-                "...and silence still gives it nothing to rise for.");
         }
         #endregion
 

--- a/Docs/TEST_FINDINGS.md
+++ b/Docs/TEST_FINDINGS.md
@@ -28,7 +28,7 @@ Findings 1-7, 15-20, 28, 30 and 33 have since been fixed and moved to
 | 36 | MonoComponent / SoundVolume | `Only Apply Once` applies only the *first* settings entry, on the very first enable | Open, characterized |
 | 37 | MonoComponent / SoundVolume | A setting typed `BroAudioType.All` writes the master volume, which `Reset On Disable` cannot restore | Open, characterized |
 | 38 | MonoComponent / SpectrumAnalyzer | Whether the serialized `SoundSource` is polled is decided once, in `Start` | Open, characterized |
-| 39 | MonoComponent / SpectrumAnalyzer | A band narrower than one FFT bin makes RMS/Average divide by zero, and the NaN drives the band below the floor forever | Open, characterized |
+| 39 | MonoComponent / SpectrumAnalyzer | A band narrower than one FFT bin makes RMS/Average divide by zero, and the band runs away to one end of the scale | Open, characterized |
 | 40 | MonoComponent / SpectrumAnalyzer | Every band draws a `Weighted` field in the inspector that the runtime never reads | Open, characterized |
 
 ---
@@ -555,7 +555,7 @@ Status: Open, characterized. Pinned by
 
 ---
 
-## 39. A `SpectrumAnalyzer` band narrower than one FFT bin runs away below the decibel floor
+## 39. A `SpectrumAnalyzer` band narrower than one FFT bin runs away off the decibel scale
 
 **Where:** `Assets/BroAudio/Runtime/MonoComponent/SpectrumAnalyzer.cs:92-184`
 
@@ -576,9 +576,12 @@ return Mathf.Sqrt(sum / range.length);   // RMS
 return sum / range.length;               // Average
 ```
 
-`0f / 0` is `NaN`, and the NaN survives `ToDecibel` (`Mathf.Clamp` returns NaN for a NaN input, and
-`Mathf.Log10(NaN)` is NaN). It then loses every comparison in the ballistics block, and each one fails
-towards *falling*:
+Which way that breaks is decided by the one bin the band still reads, and the two outcomes run in opposite
+directions.
+
+**An exactly-zero bin.** `0f / 0` is `NaN`, and the NaN survives `ToDecibel` (`Mathf.Clamp` returns NaN for a
+NaN input, and `Mathf.Log10(NaN)` is NaN). It then loses every comparison in the ballistics block, and each
+one fails towards *falling*:
 
 - `diff > 0` is false, so the slower `_decay` is chosen as the change time;
 - `Mathf.Sign(NaN)` is `-1` (it is `f >= 0f ? 1f : -1f`), so the step is negative;
@@ -586,7 +589,16 @@ towards *falling*:
 
 The band therefore subtracts a step every frame forever. `Amplitube` clamps at `MinVolume` and hides it, so a
 meter bound to the amplitude just reads silent; anything reading `DecibelVolume` gets a number that sinks
-past -80 without bound. `Metering.Peak` is unaffected - it never divides by the length.
+past -80 without bound.
+
+**A bin holding any energy at all.** `x / 0` is `+Infinity`, and there `Mathf.Clamp` does fire:
+`ClampNormalize` pins it to `MaxVolume`, so the target is `MaxDecibelVolume`. `diff > 0` now picks the much
+faster `_attack`, and the band climbs to +20dB and stays pinned there - reporting full scale for whatever is
+in one bin, including the mixer's residual noise on a silent clip. CI appears to take this branch - the first
+version of the test waited only for the fall and timed out there - which is why the test now asserts on the
+runaway rather than on its direction.
+
+`Metering.Peak` is unaffected either way - it never divides by the length.
 
 Two smaller bugs sit in the same three lines. `RangeInt.end` is `start + length`, and the metering loops run
 `i <= range.end`, so they read `length + 1` bins while `GetRMS`/`GetAverage` divide by `length` - every
@@ -594,7 +606,7 @@ non-Peak mean is inflated by `(n + 1) / n`. And a band frequency above the Nyqui
 the buffer, indexing `_spectrum` out of range every frame. Neither is pinned by a test.
 
 Status: Open, characterized. Pinned by
-`SpectrumAnalyzerTests.Update_WithABandNarrowerThanOneFftBin_SinksBelowTheFloorUnderRmsButHoldsUnderPeak`.
+`SpectrumAnalyzerTests.Update_WithABandNarrowerThanOneFftBin_LeavesTheFloorUnderRmsButHoldsUnderPeak`.
 
 ---
 


### PR DESCRIPTION
Base fixture carrying the SoundManager isolation strategy, a code-only
audio library builder, frame/DSP wait helpers, and two smoke tests that
prove a code-built entity plays a real clip through the public API.

Record the code-constructed BroAudioClip NRE in Docs/TEST_FINDINGS.md
rather than fixing it; the harness works around it via reflection.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>