### PR TITLE
Fix the ten "Fix First" items from the test suite audit

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -20,3 +20,10 @@ RUN apt-get update \
 RUN printf '%s\n' \
       'pulseaudio --system --disallow-exit --exit-idle-time=-1 --daemonize > /dev/null 2>&1 || true' \
       > /usr/bin/unity-editor.d/00-audio.sh
+
+# AudioClockProbeTests reads this to tell "this image promised an audio device and lost it" (a failure)
+# from "this machine simply has none" (a local run, which stays green). It is set here rather than in the
+# workflow because customImage is only passed on the PlayMode leg, so the variable exists exactly where a
+# realtime DSP clock is expected. Bump the image tag in test.yml when you change anything above - an
+# already-published tag is reused as-is and would never carry this.
+ENV BROAUDIO_CI_EXPECTS_AUDIO=1

--- a/.github/required-test-suites.json
+++ b/.github/required-test-suites.json
@@ -23,6 +23,7 @@
     ],
     "PlayMode": [
       "AddressablesTests",
+      "AudioClockProbeTests",
       "AudioEffectTests",
       "FadeAndTrimTests",
       "LoopHandoverTests",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,8 +43,10 @@ jobs:
       # The stock unityci/editor image ships no audio libraries, so FMOD finds no output device
       # and falls back to a non-realtime null sink pumped by the frame loop - measured at 747.94x
       # wall time, which makes every PlayMode timing test a coin flip. This image adds a
-      # timer-paced PulseAudio null sink; see .github/docker/Dockerfile. The suite's
-      # RequireRealtimeAudioClock reports the measured rate, so the results say whether it worked.
+      # timer-paced PulseAudio null sink; see .github/docker/Dockerfile. The image also sets
+      # BROAUDIO_CI_EXPECTS_AUDIO, which AudioClockProbeTests reads to fail this leg outright if the
+      # sink is not working - the 18 tests that gate on a realtime clock are Assert.Ignore'd when it
+      # is not, and an ignored test is not a failure.
       #
       # It has to come from a registry rather than a local tag: unity-test-runner runs an
       # unconditional `docker pull` on customImage before it runs the container.
@@ -56,7 +58,11 @@ jobs:
           # -linux-il2cpp-3 mirrors the tag unity-test-runner resolves for this project; the
           # trailing -3 is game-ci's image revision and moves independently of the Unity version.
           echo "base=unityci/editor:ubuntu-${version}-linux-il2cpp-3" >> "$GITHUB_OUTPUT"
-          echo "audio=ghcr.io/${{ github.repository_owner }}/unity-editor-audio:${version}" >> "$GITHUB_OUTPUT"
+          # The trailing -2 is our Dockerfile's revision, and it is load-bearing: the build step below
+          # skips the build whenever the tag already exists in the registry, so an edit to
+          # .github/docker/Dockerfile only ever reaches CI under a tag nobody has published yet. Bump it
+          # with every Dockerfile change. -2 is the revision that added BROAUDIO_CI_EXPECTS_AUDIO.
+          echo "audio=ghcr.io/${{ github.repository_owner }}/unity-editor-audio:${version}-2" >> "$GITHUB_OUTPUT"
 
       - uses: docker/login-action@v3
         if: matrix.testMode == 'PlayMode'
@@ -65,7 +71,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Built once per Unity version, then reused - the push is only paid on an editor upgrade.
+      # Built once per Unity version and Dockerfile revision, then reused - the push is only paid on an
+      # editor upgrade or a bump of the -N suffix above.
       - name: Build the editor image with an audio device
         if: matrix.testMode == 'PlayMode'
         run: |

--- a/Assets/Tests/Runtime/AddressablesTests.cs
+++ b/Assets/Tests/Runtime/AddressablesTests.cs
@@ -141,6 +141,8 @@ namespace Ami.BroAudio.Tests
             // The routine's staleness threshold is a hardcoded 60 seconds, so a test cannot wait it out.
             // Back-dating the tracked timestamp puts the entity past the threshold immediately; the routine's
             // own tick interval (clamped to at most 5s) is then the only thing left to wait for.
+            // This is the proof that the cleanup routine fires at all; the test below pins the threshold
+            // itself being hardcoded rather than driven by the setting named after it.
             SoundManager.Instance.Setting.AutomaticallyLoadAddressableAudioClips = true;
             AudioEntity entity = NewAddressableEntity("AddrCleanup", TestAudioLibrary.AddressableClipGuids[0]);
             SoundID id = IdOf(entity);
@@ -153,6 +155,43 @@ namespace Ami.BroAudio.Tests
 
             yield return WaitUntilOrTimeout(() => !SoundManager.Instance.IsLoaded(id),
                 "the cleanup routine to release the idle entity", 12f);
+        }
+
+        [UnityTest]
+        public IEnumerator CleanupRoutine_WithTheUnloadDelaySetToFiveSeconds_KeepsTheEntityLoadedAnyway()
+        {
+            // TEST_FINDINGS #14, hard pin. AutomaticallyUnloadUnusedAddressableAudioClipsAfter is not the
+            // unload delay its name promises: the routine feeds it to Mathf.Clamp(setting, 1f, 5f) as its
+            // *tick interval* only, and measures staleness against the hardcoded literal 60.0. So an entity
+            // idle for 30 seconds outlives a 5-second setting. The test above cannot show that - the
+            // setting's factory default is 60 as well, so its 61-second back-date is past either threshold.
+            //
+            // The setting written here is ignored twice over: _addressableCleanupInterval is built once,
+            // guarded by `if (_addressableCleanupInterval == null)`, on the coroutine's first iteration back
+            // at SoundManager start-up, so a mid-run write cannot move the tick rate either. The interval is
+            // therefore still the clamped default - and the clamp caps any value at 5s - which is what makes
+            // the wait below a positive result rather than a vacuous one: 12s spans at least two ticks, so
+            // the routine did run, did look at this entity, and did choose to leave it loaded.
+            //
+            // The day the setting is wired to the threshold, 30s > 5s, the entity is released and this test
+            // fails. BroAudioTestFixture restores the whole RuntimeSetting from a JSON snapshot in teardown,
+            // so the write neither leaks into the next test nor dirties the asset on disk.
+            SoundManager.Instance.Setting.AutomaticallyLoadAddressableAudioClips = true;
+            SoundManager.Instance.Setting.AutomaticallyUnloadUnusedAddressableAudioClipsAfter = 5f;
+            AudioEntity entity = NewAddressableEntity("AddrCleanupDelay", TestAudioLibrary.AddressableClipGuids[0]);
+            SoundID id = IdOf(entity);
+
+            AsyncOperationHandle<AudioClip> handle = BroAudio.LoadAssetAsync(id);
+            yield return WaitUntilOrTimeout(() => handle.IsDone, "the preload handle to complete", 10f);
+            Assert.IsTrue(SoundManager.Instance.IsLoaded(id));
+
+            BackDateLastPlayedTime(id, 30d);
+
+            yield return new WaitForSecondsRealtime(12f);
+
+            Assert.IsTrue(SoundManager.Instance.IsLoaded(id),
+                "Characterizes TEST_FINDINGS #14: 30s of idling is far past the 5s unload delay this test " +
+                "asked for, but the routine compares against its own hardcoded 60s and keeps the assets.");
         }
 
         [UnityTest]
@@ -189,6 +228,11 @@ namespace Ami.BroAudio.Tests
 
         /// <summary>
         /// Rewinds the cleanup routine's record of when this entity last played, so it reads as stale now.
+        /// <para>
+        /// The indexer write is also what *creates* that record: <c>UpdateLoadedEntityLastPlayedTime</c> is
+        /// guarded by <c>ContainsKey</c> and nothing else ever adds to the dictionary, so in a real player
+        /// it stays empty and the routine has nothing to iterate. Both cleanup tests depend on this write.
+        /// </para>
         /// </summary>
         private static void BackDateLastPlayedTime(SoundID id, double secondsAgo)
         {

--- a/Assets/Tests/Runtime/AudioClockProbeTests.cs
+++ b/Assets/Tests/Runtime/AudioClockProbeTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Ami.BroAudio.Tests
+{
+    /// <summary>
+    /// Fails the PlayMode run when the editor image's audio device is gone, instead of letting the tests
+    /// that need it quietly do nothing.
+    /// <para>
+    /// 18 tests open with <see cref="BroAudioTestFixture.RequireRealtimeAudioClock"/> — every seamless and
+    /// chained handover, nine of the thirteen spectrum analyzer tests, the scheduling pins, and the only
+    /// tests that characterize TEST_FINDINGS #38-#40. It calls <c>Assert.Ignore</c> when the DSP clock is off
+    /// wall time by more than 10%, which is right for a developer machine and silent on CI: an ignored test
+    /// is not a failure, so an image that lost its PulseAudio null sink reports green with the heart of the
+    /// suite never executed. <c>check_test_suites.py</c> cannot catch it either — the fixtures are all
+    /// present in the results, they simply ran nothing.
+    /// </para>
+    /// <para>
+    /// This is the same hole <see cref="OptionalPackageTests"/> closes for optional packages, and it draws
+    /// the same kind of line: a missing thing is only a failure where it was promised. The promise here is
+    /// <c>BROAUDIO_CI_EXPECTS_AUDIO</c>, baked into .github/docker/Dockerfile — the image CI passes as
+    /// <c>customImage</c> on the PlayMode leg only — so the variable is present exactly where an audio
+    /// device was built in and expected. Anywhere it is unset, an unrealtime clock is a fact about the
+    /// machine rather than a regression, and this test passes so a local run stays green.
+    /// </para>
+    /// </summary>
+    public class AudioClockProbeTests : BroAudioTestFixture
+    {
+        /// <summary>Set by .github/docker/Dockerfile; its presence means "this image ships an audio device".</summary>
+        private const string CiExpectsAudioVariable = "BROAUDIO_CI_EXPECTS_AUDIO";
+
+        [UnityTest]
+        public IEnumerator AudioClock_IsRealtime_SoTheTestsGatedOnItActuallyRan()
+        {
+            // The same measurement RequireRealtimeAudioClock decides on, cached for the rest of the run:
+            // this probe reports the number that gate uses, it does not take a second opinion.
+            yield return MeasureAudioClockRate();
+
+            float rate = AudioClockRate;
+            if (Mathf.Abs(rate - 1f) <= RealtimeAudioClockTolerance)
+            {
+                yield break;
+            }
+
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(CiExpectsAudioVariable)))
+            {
+                // No audio device was promised here, so the ignore gate is doing its job rather than
+                // hiding a broken image. Pass — this must not turn a local run red.
+                yield break;
+            }
+
+            Assert.Fail(
+                $"The DSP clock runs at {rate:F2}x wall time, so this run had no realtime audio output device - " +
+                $"but {CiExpectsAudioVariable} is set, meaning the editor image is supposed to provide one. " +
+                "All 18 tests that open with RequireRealtimeAudioClock were silently ignored rather than run: " +
+                "the seamless and chained handovers, most of the spectrum analyzer suite, the scheduling pins, " +
+                "and the TEST_FINDINGS #38-#40 characterizations. Everything else in this run reported green, so " +
+                "treat that green as meaningless until this passes. Check the PulseAudio null sink in " +
+                ".github/docker/Dockerfile: that the image was rebuilt after the Dockerfile last changed (the " +
+                "workflow reuses an already-published tag), and that /usr/bin/unity-editor.d/00-audio.sh still " +
+                "starts the daemon before the Editor launches.");
+        }
+    }
+}

--- a/Assets/Tests/Runtime/AudioClockProbeTests.cs
+++ b/Assets/Tests/Runtime/AudioClockProbeTests.cs
@@ -10,9 +10,11 @@ namespace Ami.BroAudio.Tests
     /// Fails the PlayMode run when the editor image's audio device is gone, instead of letting the tests
     /// that need it quietly do nothing.
     /// <para>
-    /// 18 tests open with <see cref="BroAudioTestFixture.RequireRealtimeAudioClock"/> — every seamless and
-    /// chained handover, nine of the thirteen spectrum analyzer tests, the scheduling pins, and the only
-    /// tests that characterize TEST_FINDINGS #38-#40. It calls <c>Assert.Ignore</c> when the DSP clock is off
+    /// Two dozen and counting open with <see cref="BroAudioTestFixture.RequireRealtimeAudioClock"/> — every
+    /// seamless and chained handover, most of the spectrum analyzer suite, the scheduling pins, the dominator
+    /// routing tests, and the only tests that characterize TEST_FINDINGS #38-#40. (Deliberately not an exact
+    /// count: one was written here and went stale within the week. `grep -rc "yield return
+    /// RequireRealtimeAudioClock();" Assets/Tests/Runtime/` is the current number.) It calls <c>Assert.Ignore</c> when the DSP clock is off
     /// wall time by more than 10%, which is right for a developer machine and silent on CI: an ignored test
     /// is not a failure, so an image that lost its PulseAudio null sink reports green with the heart of the
     /// suite never executed. <c>check_test_suites.py</c> cannot catch it either — the fixtures are all
@@ -55,9 +57,9 @@ namespace Ami.BroAudio.Tests
             Assert.Fail(
                 $"The DSP clock runs at {rate:F2}x wall time, so this run had no realtime audio output device - " +
                 $"but {CiExpectsAudioVariable} is set, meaning the editor image is supposed to provide one. " +
-                "All 18 tests that open with RequireRealtimeAudioClock were silently ignored rather than run: " +
+                "Every test that opens with RequireRealtimeAudioClock was silently ignored rather than run: " +
                 "the seamless and chained handovers, most of the spectrum analyzer suite, the scheduling pins, " +
-                "and the TEST_FINDINGS #38-#40 characterizations. Everything else in this run reported green, so " +
+                "the dominator routing tests, and the TEST_FINDINGS #38-#40 characterizations. Everything else in this run reported green, so " +
                 "treat that green as meaningless until this passes. Check the PulseAudio null sink in " +
                 ".github/docker/Dockerfile: that the image was rebuilt after the Dockerfile last changed (the " +
                 "workflow reuses an already-published tag), and that /usr/bin/unity-editor.d/00-audio.sh still " +

--- a/Assets/Tests/Runtime/AudioClockProbeTests.cs.meta
+++ b/Assets/Tests/Runtime/AudioClockProbeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a5563e7b2b5641328928a7d1bc534e53

--- a/Assets/Tests/Runtime/AudioEffectTests.cs
+++ b/Assets/Tests/Runtime/AudioEffectTests.cs
@@ -248,9 +248,11 @@ namespace Ami.BroAudio.Tests
             Assert.IsTrue(SoundManager.Instance.AudioMixer.GetFloat(BroName.LowPassParaName, out float freq));
             Assert.AreEqual(800f, freq, FrequencyTolerance, "SetEffect(Effect.LowPass) should move the exposed mixer parameter to the requested frequency.");
 
-            // SetEffect only updates the per-type pref that's read when a NEW player starts
-            // (AudioPlayer.Playback.cs: SetTrackEffect(audioTypePref.EffectType, Add)) - it does not
-            // retroactively re-route a player that was already playing before SetEffect was called.
+            // SetEffect does two things: it updates the per-type pref that's read when a NEW player
+            // starts (AudioPlayer.Playback.cs: SetTrackEffect(audioTypePref.EffectType, Add)), and
+            // SoundManager.SetPlayerEffect re-routes every player of the target type that is already
+            // playing. This test pins the future-player half; the live re-route and the type scoping
+            // are covered by SetEffect_ScopedToMusic_ReroutesLivePlayerOfThatTypeOnly below.
             SoundID id = NewSound("EffectSendFx", BroAudioType.SFX, NewClip(2f));
             IAudioPlayer player = BroAudio.Play(id);
             yield return WaitForPlaybackStart(player);
@@ -258,6 +260,46 @@ namespace Ami.BroAudio.Tests
             AudioPlayer concrete = Underlying(player);
             Assert.IsTrue(concrete.IsUsingTrackEffect, "A player started after SetEffect(LowPass) should route through the effect send channel.");
             Assert.AreNotEqual(EffectType.None, concrete.CurrentActiveTrackEffects & EffectType.LowPass, "LowPass should be part of the player's active track effects.");
+        }
+
+        [UnityTest]
+        public IEnumerator SetEffect_ScopedToMusic_ReroutesLivePlayerOfThatTypeOnly()
+        {
+            SoundID musicId = NewSound("ScopedBgm", BroAudioType.Music, NewClip(4f));
+            SoundID sfxId = NewSound("ScopedSfx", BroAudioType.SFX, NewClip(4f));
+            IAudioPlayer musicPlayer = BroAudio.Play(musicId);
+            IAudioPlayer sfxPlayer = BroAudio.Play(sfxId);
+            yield return WaitForPlaybackStart(musicPlayer, "the Music playback to start");
+            yield return WaitForPlaybackStart(sfxPlayer, "the SFX playback to start");
+
+            AudioPlayer music = Underlying(musicPlayer);
+            AudioPlayer sfx = Underlying(sfxPlayer);
+            Assert.IsFalse(music.IsUsingTrackEffect, "Precondition: the Music player should start on its plain track.");
+            Assert.IsFalse(sfx.IsUsingTrackEffect, "Precondition: the SFX player should start on its plain track.");
+
+            // characterizes: SoundManager.SetPlayerEffect walks GetCurrentAudioPlayers() and calls
+            // player.SetTrackEffect(effectType, mode) on every active non-Dominator player whose audio
+            // type the target type contains - so a player that was ALREADY playing gets re-routed too,
+            // and a player of any other type is left alone.
+            BroAudio.SetEffect(Effect.LowPass(800f), BroAudioType.Music);
+            yield return WaitUntilOrTimeout(() => music.IsUsingTrackEffect,
+                "the already-playing Music player to be re-routed through the effect send", 2f);
+
+            Assert.AreNotEqual(EffectType.None, music.CurrentActiveTrackEffects & EffectType.LowPass,
+                "LowPass should be part of the live Music player's active track effects.");
+            Assert.AreEqual(EffectType.None, sfx.CurrentActiveTrackEffects,
+                "An effect scoped to Music must not re-route a live SFX player.");
+
+            // The facade has no Reset* verb of its own (BroAudio.cs exposes only the two SetEffect
+            // overloads) - resetting means handing SetEffect a default-valued Effect. Effect.ResetLowPass()
+            // is default, so SoundManager picks SetEffectMode.Remove, and that mode defers SetPlayerEffect
+            // to the automation helper's onReset callback rather than running it inline; hence the poll.
+            yield return ResetLowPassEffect();
+            yield return WaitUntilOrTimeout(() => !music.IsUsingTrackEffect,
+                "the reset to remove the Music player's track effect", 2f);
+
+            Assert.AreEqual(EffectType.None, music.CurrentActiveTrackEffects, "The reset should leave the Music player with no active track effect.");
+            Assert.AreEqual(EffectType.None, sfx.CurrentActiveTrackEffects, "The reset should leave the untouched SFX player clear as well.");
         }
 
         [UnityTest]

--- a/Assets/Tests/Runtime/BroAudioTestFixture.cs
+++ b/Assets/Tests/Runtime/BroAudioTestFixture.cs
@@ -68,6 +68,17 @@ namespace Ami.BroAudio.Tests
                 BroAudio.SetVolume(audioType, AudioConstant.FullVolume, 0f);
             }
 
+            // Per-type pitch leaks exactly like per-type volume: SoundManager.SetPitch stores it into
+            // AudioTypePlaybackPreference (SoundManager.cs:358), so every *later* player of that type picks
+            // it up through SetInitialPitch. Volume only shifts an amplitude, but pitch rescales duration -
+            // a leaked 0.5x makes every later clip run twice as long and moves every duration window in the
+            // fade, scheduling and loop tests. Mind the argument order: SetPitch(type, pitch, fadeTime) is
+            // the current overload (BroAudio.cs:245); SetPitch(pitch, type, fadeTime) is [Obsolete] (:237).
+            foreach (BroAudioType audioType in ConcreteAudioTypes)
+            {
+                BroAudio.SetPitch(audioType, AudioConstant.DefaultPitch, 0f);
+            }
+
             // BroAudio.OnBGMChanged forwards to a *static* event on MusicPlayer — an un-removed handler
             // outlives the test and fires during every later one.
             foreach (Action<IAudioPlayer> handler in _bgmSubscriptions)
@@ -162,12 +173,22 @@ namespace Ami.BroAudio.Tests
 
         private static float _audioClockRate = -1f;
 
+        /// <summary>How far the DSP clock may drift from wall time before it counts as unrealtime.</summary>
+        protected const float RealtimeAudioClockTolerance = 0.1f;
+
         /// <summary>
-        /// A machine with no audio output device (CI runners) runs the engine's DSP clock decoupled from
-        /// wall time, so a voice can start and finish between two frames. Tests that need the voice itself
-        /// to advance in real time gate on this; the rate is measured once and reused for the whole run.
+        /// The DSP clock's rate as a multiple of wall time, as last measured by
+        /// <see cref="MeasureAudioClockRate"/>; negative before the first measurement. 1 means a real
+        /// output device. Exposed so <see cref="AudioClockProbeTests"/> can report on the same number the
+        /// ignore gate below decides on, rather than measuring a second, possibly different one.
         /// </summary>
-        protected static IEnumerator RequireRealtimeAudioClock()
+        protected static float AudioClockRate => _audioClockRate;
+
+        /// <summary>
+        /// Measures the DSP clock against wall time, once per run — the result is cached in
+        /// <see cref="AudioClockRate"/> and every later call returns immediately.
+        /// </summary>
+        protected static IEnumerator MeasureAudioClockRate()
         {
             if (_audioClockRate < 0f)
             {
@@ -176,8 +197,23 @@ namespace Ami.BroAudio.Tests
                 yield return new WaitForSecondsRealtime(0.25f);
                 _audioClockRate = (float)((AudioSettings.dspTime - dspStart) / (Time.realtimeSinceStartup - realStart));
             }
+        }
 
-            if (Mathf.Abs(_audioClockRate - 1f) > 0.1f)
+        /// <summary>
+        /// A machine with no audio output device (CI runners) runs the engine's DSP clock decoupled from
+        /// wall time, so a voice can start and finish between two frames. Tests that need the voice itself
+        /// to advance in real time gate on this; the rate is measured once and reused for the whole run.
+        /// <para>
+        /// This ignores rather than fails, so a local run without an audio device stays green.
+        /// <see cref="AudioClockProbeTests"/> is what turns the same condition into a CI failure — without
+        /// it, an image that lost its audio device silently skips every test that gates on this.
+        /// </para>
+        /// </summary>
+        protected static IEnumerator RequireRealtimeAudioClock()
+        {
+            yield return MeasureAudioClockRate();
+
+            if (Mathf.Abs(_audioClockRate - 1f) > RealtimeAudioClockTolerance)
             {
                 Assert.Ignore($"DSP clock runs at {_audioClockRate:F2}x wall time (no audio output device) - this test needs a realtime audio clock.");
             }
@@ -191,11 +227,29 @@ namespace Ami.BroAudio.Tests
         /// those with WaitForSeconds — a machine with no audio device runs the two clocks at different rates.
         /// </para>
         /// </summary>
-        protected static IEnumerator WaitDspSeconds(double seconds)
+        /// <param name="timeout">
+        /// Realtime deadline. Negative derives one from <paramref name="seconds"/>, generously: the DSP clock
+        /// is never slower than wall time in practice (a machine with no audio device runs it hundreds of
+        /// times faster, returning almost immediately), so the derived deadline only has to outlast a
+        /// realtime clock plus scheduling noise — it exists to name a stalled clock, not to time anything.
+        /// </param>
+        protected static IEnumerator WaitDspSeconds(double seconds, float timeout = -1f)
         {
-            double target = AudioSettings.dspTime + seconds;
+            if (timeout < 0f)
+            {
+                timeout = ((float)seconds * 4f) + 5f;
+            }
+
+            float deadline = Time.realtimeSinceStartup + timeout;
+            double dspStart = AudioSettings.dspTime;
+            double target = dspStart + seconds;
             while (AudioSettings.dspTime < target)
             {
+                if (Time.realtimeSinceStartup > deadline)
+                {
+                    Assert.Fail($"DSP clock stalled: after {timeout}s of wall time it had advanced only " +
+                                $"{AudioSettings.dspTime - dspStart:F3}s of the {seconds}s waited for.");
+                }
                 yield return null;
             }
         }

--- a/Assets/Tests/Runtime/FadeAndTrimTests.cs
+++ b/Assets/Tests/Runtime/FadeAndTrimTests.cs
@@ -64,12 +64,19 @@ namespace Ami.BroAudio.Tests
         [UnityTest]
         public IEnumerator Play_WithClipFadeOut_RampsVolumeDownBeforeNaturalEnd()
         {
+            // The IsPlaying assertion below straddles both clocks: it reads a DSP-driven voice at an instant
+            // the frame-clocked ramp chooses, so the two have to run at the same rate. On a machine with no
+            // audio output device the voice is long finished by the time the ramp crosses the threshold, and
+            // this test would go red where the suite deliberately stays green.
+            yield return RequireRealtimeAudioClock();
+
             // 3s clip with a 1.5s fade-out (was 1.6s / 0.5s). The default fade-out ease is OutSine
             // (RuntimeSetting.FactorySettings.DefaultFadeOutEase - no BroRuntimeSetting asset ships in this
             // project, so the factory values apply), i.e. volume = 1 - sin(t/T * pi/2), which crosses the 0.5
-            // poll threshold below a third of the way in. At 1.5s that is 0.5s into the ramp with a full
-            // second of audio still to play when the assertions below run; at the old 0.5s fade only 0.17s
-            // remained - less than one capped hitch frame (Time.maximumDeltaTime ~0.333s).
+            // poll threshold exactly a third of the way in (sin(pi/6) = 0.5). At 1.5s that is 0.5s into the
+            // ramp with a full second of audio still to play when the assertions below run; at the old 0.5s
+            // fade the crossing sat 0.17s in with only 0.33s of audio left - one capped hitch frame
+            // (Time.maximumDeltaTime ~0.333s).
             const float clipLength = 3f;
             const float fadeOut = 1.5f;
             AudioClip clip = NewClip(clipLength);
@@ -104,8 +111,9 @@ namespace Ami.BroAudio.Tests
         {
             // A 4s override on a 5s clip (was 0.6s on 1.2s), with both halves decided at observationTime.
             // The default fade-in ease is InCubic (RuntimeSetting.FactorySettings.DefaultFadeInEase), i.e.
-            // volume = t^3, so a fade only crosses NearTargetThreshold at ~98% of its length: the override
-            // cannot reach target before ~3.93s, while the clip's own 0.15s fade is there in a frame or two.
+            // volume = t^3, so a fade only crosses NearTargetThreshold at 98.3% of its length (0.95^(1/3)):
+            // the override cannot reach target before ~3.93s, while the clip's own 0.15s fade is there in
+            // 0.15s.
             const float clipFadeIn = 0.15f;
             const float overrideFadeIn = 4f;
             const float observationTime = 1.2f;
@@ -119,9 +127,10 @@ namespace Ami.BroAudio.Tests
 
             // By now the clip's own 0.15s fade would long be done; the 4s explicit override needs ~3.93s, so
             // this read sits 2.7s clear of the point where it could start failing on a correct build (was
-            // 0.25s against a 0.6s override - 0.10s of slack). A hitch only ever makes WaitForSeconds
-            // overshoot, and overshoot is the safe direction for the other side of the window: the further
-            // past 0.15s this lands, the more certain a regression that used the clip setting reads at target.
+            // 0.25s against a 0.6s override, whose ramp crossed at 0.59s - 0.34s of slack). A hitch only ever
+            // makes WaitForSeconds overshoot, and overshoot is the safe direction for the other side of the
+            // window: the further past 0.15s this lands, the more certain a regression that used the clip
+            // setting reads at target.
             yield return new WaitForSeconds(observationTime);
             Assert.Less(firstPlayer.GetVolume(), NearTargetThreshold,
                 "The explicit fadeIn override should still be ramping well past the clip's own (shorter) FadeIn duration - FadeData.cs's one-shot Next override should have taken priority over the clip setting.");
@@ -135,9 +144,9 @@ namespace Ami.BroAudio.Tests
             // The override was consumed by TryGetOrConsumeOverride during the first play (FadeData.cs); this
             // play should fall back to only the clip's own short FadeIn. Poll for the target instead of
             // sampling at a fixed instant (was a bare 0.25s wait then an assert - 0.10s of slack over a 0.15s
-            // frame-clock fade): the clip's own fade is at target within a frame or two, so observationTime
-            // leaves ~1s for frame-clock lag, while a leaked 4s override would not get there for ~3.93s and
-            // so still times out by 2.7s.
+            // frame-clock fade): the clip's own fade is at target at ~0.15s, so observationTime leaves ~1s
+            // for frame-clock lag, while a leaked 4s override would not get there for ~3.93s and so still
+            // times out by 2.7s.
             yield return WaitUntilOrTimeout(() => secondPlayer.GetVolume() >= NearTargetThreshold,
                 "the second play to reach target volume on the clip's own short FadeIn - timing out here means the one-shot override leaked into a later play",
                 observationTime);
@@ -194,6 +203,12 @@ namespace Ami.BroAudio.Tests
         [UnityTest]
         public IEnumerator Play_WithClipEndPosition_EndsPlaybackBeforeClipLength()
         {
+            // This measures a DSP interval with a per-frame poll, so the two clocks have to run at the same
+            // rate: on a machine with no audio output device a single frame carries the DSP clock seconds
+            // past the scheduled end, and the elapsed reading blows through the tolerance below. Pre-existing
+            // rather than introduced by the widened window, but red where the suite means to stay green.
+            yield return RequireRealtimeAudioClock();
+
             // 4s clip trimmed by 1.5s (was 2s trimmed by 0.8s), so the measured duration is 2.5s and the
             // widened tolerance below is a fifth of it rather than a quarter.
             const float clipLength = 4f;
@@ -247,9 +262,11 @@ namespace Ami.BroAudio.Tests
             // leaving ~1.35s for hitch frames and frame-clock lag, while an un-ignored 4s ramp would not end
             // until ~4.05s, 1.85s past the deadline. A timeout still means either the original fade stalled
             // or the guard regressed - not proof of either on its own, hence the hedged message.
-            // Sampling the ramp mid-flight instead was considered and rejected: a restarted fade inherits
-            // the volume already reached (~0.9) rather than starting from 1, and with the OutSine ease a
-            // fresh 2s ramp would cross 0.5 only ~0.09s after a 0.5s-in sample point - no window at all.
+            // Sampling the ramp mid-flight was considered and rejected in favour of this state transition:
+            // a restarted fade inherits the volume already reached (Fader.SetTarget re-bases _origin on
+            // Current, ~0.9 after the three frames above) rather than starting from 1, so a mid-flight
+            // threshold has to be derived from that moving origin and read on a particular frame, while
+            // !IsActive is a one-way transition with more than a second of margin on either side.
             yield return WaitUntilOrTimeout(() => !player.IsActive,
                 "the original 0.8s fade-out to finish (a timeout here does not by itself prove the second Stop(4f) call went through)", 2.2f);
         }
@@ -268,15 +285,16 @@ namespace Ami.BroAudio.Tests
 
             // Unlike a second non-immediate Stop, an explicit FadeData.Immediate (0f) passes the IsStopping
             // guard (`!Mathf.Approximately(overrideFade, FadeData.Immediate)` is false for 0f), so
-            // RestartCoroutine cancels the in-flight fade and StopControl ends playback with no fade instead
-            // of waiting out the original 3s ramp.
+            // RestartCoroutine replaces the in-flight StopControl and the new one ends playback with no fade
+            // instead of waiting out the original 3s ramp. The fader's own coroutine is stopped one step
+            // later, by EndPlaying's ResetVolume completing it.
             player.Stop(FadeData.Immediate);
 
             // A 3s original fade and a 1.2s deadline (was 1s and 0.3s - under one capped hitch frame at
             // Time.maximumDeltaTime ~0.333s). A zero-length fade makes PlaybackPreference.TryGetFadeOut
             // return false, so StopControl skips the fade block entirely and reaches EndPlaying before
             // StartCoroutine even returns; the whole deadline is slack. The ramp it pre-empted would not
-            // have finished until ~3.05s, so the two outcomes sit 1.85s apart around the deadline.
+            // have finished until ~3.05s, which is 1.85s past the deadline.
             yield return WaitUntilOrTimeout(() => !player.IsActive,
                 "the immediate Stop to end playback promptly, well before the original 3s fade-out would have finished", 1.2f);
         }

--- a/Assets/Tests/Runtime/FadeAndTrimTests.cs
+++ b/Assets/Tests/Runtime/FadeAndTrimTests.cs
@@ -64,8 +64,14 @@ namespace Ami.BroAudio.Tests
         [UnityTest]
         public IEnumerator Play_WithClipFadeOut_RampsVolumeDownBeforeNaturalEnd()
         {
-            const float clipLength = 1.6f;
-            const float fadeOut = 0.5f;
+            // 3s clip with a 1.5s fade-out (was 1.6s / 0.5s). The default fade-out ease is OutSine
+            // (RuntimeSetting.FactorySettings.DefaultFadeOutEase - no BroRuntimeSetting asset ships in this
+            // project, so the factory values apply), i.e. volume = 1 - sin(t/T * pi/2), which crosses the 0.5
+            // poll threshold below a third of the way in. At 1.5s that is 0.5s into the ramp with a full
+            // second of audio still to play when the assertions below run; at the old 0.5s fade only 0.17s
+            // remained - less than one capped hitch frame (Time.maximumDeltaTime ~0.333s).
+            const float clipLength = 3f;
+            const float fadeOut = 1.5f;
             AudioClip clip = NewClip(clipLength);
             AudioEntity entity = NewEntity("FadeOutSfx", BroAudioType.SFX, clip);
             entity.Clips[0].FadeOut = fadeOut;
@@ -79,8 +85,16 @@ namespace Ami.BroAudio.Tests
 
             // The wait-to-start-fading gate (dspTime < end - fadeOut) is DSP-clocked; the ramp itself runs on
             // the frame clock. Poll for the drop rather than computing the exact DSP gate boundary.
-            yield return WaitUntilOrTimeout(() => player.GetVolume() < 0.5f,
-                "the natural-end fade-out to begin ramping the volume down", clipLength + 0.3f);
+            // IsActive is part of the condition because AudioPlayerInstanceWrapper's IAudioPlayer.GetVolume()
+            // returns 0f for a recycled instance: without it the poll is satisfied by the natural end itself,
+            // which is the one outcome this test must not accept as evidence of a ramp. IsActive and
+            // IsPlaying both resolve through IsAvailable(false), so neither logs the recycled-player warning.
+            yield return WaitUntilOrTimeout(() => player.IsActive && player.GetVolume() < 0.5f,
+                "the natural-end fade-out to ramp a still-live player below half volume (timing out here means no such drop was ever seen while the player was active, which includes playback simply ending with no ramp at all)",
+                clipLength + 1f);
+            Assert.IsTrue(player.IsPlaying,
+                "The drop below half volume must be observed while the player is still playing, not after playback has already ended.");
+
             yield return WaitUntilOrTimeout(() => !player.IsActive,
                 "playback to end once the fade-out completes", fadeOut + 1f);
         }
@@ -88,9 +102,14 @@ namespace Ami.BroAudio.Tests
         [UnityTest]
         public IEnumerator Play_WithExplicitFadeInOverride_IsConsumedOnceThenFallsBackToClipSetting()
         {
+            // A 4s override on a 5s clip (was 0.6s on 1.2s), with both halves decided at observationTime.
+            // The default fade-in ease is InCubic (RuntimeSetting.FactorySettings.DefaultFadeInEase), i.e.
+            // volume = t^3, so a fade only crosses NearTargetThreshold at ~98% of its length: the override
+            // cannot reach target before ~3.93s, while the clip's own 0.15s fade is there in a frame or two.
             const float clipFadeIn = 0.15f;
-            const float overrideFadeIn = 0.6f;
-            AudioClip clip = NewClip(1.2f);
+            const float overrideFadeIn = 4f;
+            const float observationTime = 1.2f;
+            AudioClip clip = NewClip(5f);
             AudioEntity entity = NewEntity("FadeOverrideSfx", BroAudioType.SFX, clip);
             entity.Clips[0].FadeIn = clipFadeIn;
             SoundID id = IdOf(entity);
@@ -98,8 +117,12 @@ namespace Ami.BroAudio.Tests
             IAudioPlayer firstPlayer = BroAudio.Play(id, overrideFadeIn);
             yield return WaitForPlaybackStart(firstPlayer, "first playback to start");
 
-            // By now the clip's own 0.15s fade would already be done; the 0.6s explicit override should not be.
-            yield return new WaitForSeconds(clipFadeIn + 0.1f);
+            // By now the clip's own 0.15s fade would long be done; the 4s explicit override needs ~3.93s, so
+            // this read sits 2.7s clear of the point where it could start failing on a correct build (was
+            // 0.25s against a 0.6s override - 0.10s of slack). A hitch only ever makes WaitForSeconds
+            // overshoot, and overshoot is the safe direction for the other side of the window: the further
+            // past 0.15s this lands, the more certain a regression that used the clip setting reads at target.
+            yield return new WaitForSeconds(observationTime);
             Assert.Less(firstPlayer.GetVolume(), NearTargetThreshold,
                 "The explicit fadeIn override should still be ramping well past the clip's own (shorter) FadeIn duration - FadeData.cs's one-shot Next override should have taken priority over the clip setting.");
 
@@ -110,10 +133,14 @@ namespace Ami.BroAudio.Tests
             yield return WaitForPlaybackStart(secondPlayer, "second playback to start");
 
             // The override was consumed by TryGetOrConsumeOverride during the first play (FadeData.cs); this
-            // play should fall back to only the clip's own short FadeIn.
-            yield return new WaitForSeconds(clipFadeIn + 0.1f);
-            Assert.GreaterOrEqual(secondPlayer.GetVolume(), NearTargetThreshold,
-                "Without a fresh override, the second play should already be at target using the clip's own short FadeIn - the one-shot override must not leak into a later play.");
+            // play should fall back to only the clip's own short FadeIn. Poll for the target instead of
+            // sampling at a fixed instant (was a bare 0.25s wait then an assert - 0.10s of slack over a 0.15s
+            // frame-clock fade): the clip's own fade is at target within a frame or two, so observationTime
+            // leaves ~1s for frame-clock lag, while a leaked 4s override would not get there for ~3.93s and
+            // so still times out by 2.7s.
+            yield return WaitUntilOrTimeout(() => secondPlayer.GetVolume() >= NearTargetThreshold,
+                "the second play to reach target volume on the clip's own short FadeIn - timing out here means the one-shot override leaked into a later play",
+                observationTime);
         }
 
         [UnityTest]
@@ -167,8 +194,10 @@ namespace Ami.BroAudio.Tests
         [UnityTest]
         public IEnumerator Play_WithClipEndPosition_EndsPlaybackBeforeClipLength()
         {
-            const float clipLength = 2f;
-            const float endPosition = 0.8f;
+            // 4s clip trimmed by 1.5s (was 2s trimmed by 0.8s), so the measured duration is 2.5s and the
+            // widened tolerance below is a fifth of it rather than a quarter.
+            const float clipLength = 4f;
+            const float endPosition = 1.5f;
             AudioClip clip = NewClip(clipLength);
             AudioEntity entity = NewEntity("EndPosSfx", BroAudioType.SFX, clip);
             entity.Clips[0].EndPosition = endPosition;
@@ -183,18 +212,22 @@ namespace Ami.BroAudio.Tests
             double elapsed = AudioSettings.dspTime - dspStart;
             const float expectedDuration = clipLength - endPosition;
 
-            Assert.Less(elapsed, clipLength - 0.3, "EndPosition should make playback end well before the clip's full length.");
-            // 0.3s tolerance: the DSP-scheduled end (Utility.GetPlayableDuration, computed once at play start)
-            // is exact, but our own dspStart sample and the !IsActive poll both land a frame or two off the
-            // true boundary.
-            Assert.AreEqual(expectedDuration, elapsed, 0.3,
+            Assert.Less(elapsed, clipLength - 0.5, "EndPosition should make playback end well before the clip's full length.");
+            // 0.5s tolerance (was 0.3s, under a single capped hitch frame at Time.maximumDeltaTime ~0.333s):
+            // the DSP-scheduled end (Utility.GetPlayableDuration, computed once at play start) is exact, but
+            // our own dspStart sample and the per-frame !IsActive poll both land a frame or two off the true
+            // boundary, and one hitch frame makes each of those a third of a second. Still decisive: a
+            // regression that ignored EndPosition entirely would measure 4s - three whole tolerances past
+            // the 2.5s expected here.
+            Assert.AreEqual(expectedDuration, elapsed, 0.5,
                 "Measured playback duration should match clip length minus EndPosition.");
         }
 
         [UnityTest]
         public IEnumerator Stop_SecondNonImmediateCall_WhileFadeOutInFlight_IsIgnored()
         {
-            SoundID id = NewSound("StopGuardSfx", BroAudioType.SFX, NewClip(3f));
+            // 6s clip so the voice outlasts both outcomes below, including the regressed one at ~4.05s.
+            SoundID id = NewSound("StopGuardSfx", BroAudioType.SFX, NewClip(6f));
             IAudioPlayer player = BroAudio.Play(id);
             yield return WaitForPlaybackStart(player);
 
@@ -205,37 +238,47 @@ namespace Ami.BroAudio.Tests
             // AudioPlayer.Playback.cs's Stop() guard: `if (IsStopping && !Mathf.Approximately(overrideFade,
             // FadeData.Immediate)) return;`. While a fade-out is already in flight, a second non-immediate
             // Stop is silently dropped rather than restarting RestartCoroutine on a fresh ramp. If this ever
-            // regresses, a fresh 2s fade would begin here and the wait below would time out.
-            player.Stop(2f);
+            // regresses, a fresh 4s fade would begin here and the wait below would time out.
+            player.Stop(4f);
 
-            // 1.8s deadline (was 1.3s, thin enough that a single capped hitch frame plus the 3 frames
-            // already burned above could outrun the ~0.7s of fade actually remaining). Still well short
-            // of the ~2s a genuinely un-ignored Stop(2f) would take to ramp down from here, so a timeout
-            // here means either the original fade stalled or the guard regressed - not proof of either on
-            // its own, unlike the old message which asserted the guard specifically.
+            // A 4s second fade and a 2.2s deadline (was 2s and 1.8s, which left only 0.2s between the
+            // deadline and where a regressed ramp lands). The two outcomes are now more than a second clear
+            // of the deadline in both directions: the original 0.8s fade ends ~0.85s after it started,
+            // leaving ~1.35s for hitch frames and frame-clock lag, while an un-ignored 4s ramp would not end
+            // until ~4.05s, 1.85s past the deadline. A timeout still means either the original fade stalled
+            // or the guard regressed - not proof of either on its own, hence the hedged message.
+            // Sampling the ramp mid-flight instead was considered and rejected: a restarted fade inherits
+            // the volume already reached (~0.9) rather than starting from 1, and with the OutSine ease a
+            // fresh 2s ramp would cross 0.5 only ~0.09s after a 0.5s-in sample point - no window at all.
             yield return WaitUntilOrTimeout(() => !player.IsActive,
-                "the original 0.8s fade-out to finish (a timeout here does not by itself prove the second Stop(2f) call went through)", 1.8f);
+                "the original 0.8s fade-out to finish (a timeout here does not by itself prove the second Stop(4f) call went through)", 2.2f);
         }
 
         [UnityTest]
         public IEnumerator Stop_WithImmediateFade_PassesGuardAndEndsPromptly()
         {
-            SoundID id = NewSound("StopImmediateSfx", BroAudioType.SFX, NewClip(3f));
+            // 5s clip so the voice outlasts the 3s ramp a regression would run to completion.
+            SoundID id = NewSound("StopImmediateSfx", BroAudioType.SFX, NewClip(5f));
             IAudioPlayer player = BroAudio.Play(id);
             yield return WaitForPlaybackStart(player);
 
-            player.Stop(1f); // Starts a 1s fade-out.
+            player.Stop(3f); // Starts a 3s fade-out.
             yield return WaitFrames(3);
-            Assert.IsTrue(player.IsActive, "The 1s fade-out should still be in flight.");
+            Assert.IsTrue(player.IsActive, "The 3s fade-out should still be in flight.");
 
             // Unlike a second non-immediate Stop, an explicit FadeData.Immediate (0f) passes the IsStopping
             // guard (`!Mathf.Approximately(overrideFade, FadeData.Immediate)` is false for 0f), so
             // RestartCoroutine cancels the in-flight fade and StopControl ends playback with no fade instead
-            // of waiting out the original 1s ramp.
+            // of waiting out the original 3s ramp.
             player.Stop(FadeData.Immediate);
 
+            // A 3s original fade and a 1.2s deadline (was 1s and 0.3s - under one capped hitch frame at
+            // Time.maximumDeltaTime ~0.333s). A zero-length fade makes PlaybackPreference.TryGetFadeOut
+            // return false, so StopControl skips the fade block entirely and reaches EndPlaying before
+            // StartCoroutine even returns; the whole deadline is slack. The ramp it pre-empted would not
+            // have finished until ~3.05s, so the two outcomes sit 1.85s apart around the deadline.
             yield return WaitUntilOrTimeout(() => !player.IsActive,
-                "the immediate Stop to end playback promptly, well before the original 1s fade-out would have finished", 0.3f);
+                "the immediate Stop to end playback promptly, well before the original 3s fade-out would have finished", 1.2f);
         }
     }
 }

--- a/Assets/Tests/Runtime/LoopHandoverTests.cs
+++ b/Assets/Tests/Runtime/LoopHandoverTests.cs
@@ -15,11 +15,17 @@ namespace Ami.BroAudio.Tests
     /// handover rather than AudioSource.loop. See Docs/inventory/time-dependent.md, sections
     /// "Plain looping", "Seamless looping", "Chained playback", "Pause across a handover seam".
     /// <para>
-    /// A handed-over sound is tracked through BroAudio.HasAnyPlayingInstances and through the
-    /// GetActivePlayers reflection helper below (a thin window onto SoundManager's private player pool),
-    /// never by asserting that the original IAudioPlayer handle's IsPlaying stays true across a seam -
-    /// whether a caller's handle keeps tracking the sound after a handover is exactly the kind of internal
-    /// detail these tests deliberately do not depend on either way.
+    /// This file takes it as contract that the IAudioPlayer handle a caller kept keeps driving the sound
+    /// across a handover seam. AudioPlayerInstanceWrapper.UpdateInstance (AudioPlayerInstanceWrapper.cs:112-156)
+    /// exists for no other reason - it re-points the wrapper at the incoming player and carries the
+    /// registered callbacks, decorators and added effect components over - and looping BGM, the default use
+    /// of this library, leaves its owner with no handle other than the one Play returned. So the survival of
+    /// that handle is public API, not an internal detail:
+    /// Play_WithPlainLoop_HandleKeepsDrivingTheSoundAcrossTwoSeams pins it directly, driving SetVolume,
+    /// OnEnd and Stop on the original handle after two handovers. The other tests here still track a
+    /// handed-over sound through BroAudio.HasAnyPlayingInstances and through the GetActivePlayers reflection
+    /// helper below (a thin window onto SoundManager's private player pool), because what they are about is
+    /// which players exist and what each one is playing, not what the caller's handle points at.
     /// </para>
     /// <para>
     /// Not included: the inventory's "transition time longer than the clip" edge case for SeamlessLoop.
@@ -99,6 +105,71 @@ namespace Ami.BroAudio.Tests
                 "the dsp clock to pass a second loop seam", 5f);
             Assert.IsTrue(BroAudio.HasAnyPlayingInstances(id),
                 "The loop must survive a second seam too, not just the first.");
+        }
+
+        // 2.2 (handle continuity) - the other half of the same handover: what the caller is left holding.
+        // ScheduleNextPlayback bakes the outgoing player's _trackVolume.Target into
+        // PlaybackHandoverData.TrackVolume (AudioPlayer.Playback.cs:354) and ReceiveHandover completes the
+        // incoming player's fader on it (line 399), while UpdateInstance moves the registered onEnd
+        // delegates to the incoming player and leaves the outgoing player's _onEnd null
+        // (AudioPlayerInstanceWrapper.cs:128-134 via AudioPlayer.TransferOnEnds, AudioPlayer.cs:341-350) -
+        // so EndPlaying's _onEnd?.Invoke (AudioPlayer.Playback.cs:570) is a no-op at a seam and fires once,
+        // at the real end. None of that is observable except through the handle the caller kept.
+        // A plain loop rather than a seamless one on purpose: with no crossfade, _clipVolume sits completed
+        // at its target the whole time, so GetVolume() reads back the track volume alone.
+        [UnityTest]
+        public IEnumerator Play_WithPlainLoop_HandleKeepsDrivingTheSoundAcrossTwoSeams()
+        {
+            yield return RequireRealtimeAudioClock();
+
+            const float ClipSeconds = 0.4f;
+            const float TargetVolume = 0.3f;
+            const float VolumeTolerance = 0.01f;
+            AudioEntity entity = NewEntity("HandoverHandleSfx", BroAudioType.SFX, NewClip(ClipSeconds));
+            TestAudioLibrary.SetPrivateField(entity, "Loop", true);
+            SoundID id = IdOf(entity);
+
+            double? startDsp = null;
+            int onEndCount = 0;
+            IAudioPlayer player = BroAudio.Play(id);
+            player.OnStart(_ => startDsp ??= AudioSettings.dspTime);
+
+            yield return WaitForPlaybackStart(player);
+            yield return WaitUntilOrTimeout(() => startDsp.HasValue, "OnStart to fire for the first iteration", 2f);
+
+            // Both are registered on the first player, well before the first seam. GetVolume() is
+            // _clipVolume.Current * _trackVolume.Current * _audioTypeVolume.Current (AudioPlayer.Volume.cs:113-116);
+            // the latter two are 1 here, so it reads back exactly what SetVolume put on the track fader.
+            player.OnEnd(_ => onEndCount++);
+            player.SetVolume(TargetVolume);
+            Assert.AreEqual(TargetVolume, player.GetVolume(), VolumeTolerance,
+                "Precondition: SetVolume must land on the first player before any handover.");
+
+            double secondSeamDsp = startDsp.Value + (ClipSeconds * 2);
+            yield return WaitUntilOrTimeout(() => AudioSettings.dspTime >= secondSeamDsp + 0.2,
+                "the dsp clock to pass two loop seams", 5f);
+
+            // If the handle had been left behind on the first player, the wrapper would have been recycled
+            // with it (AudioPlayer.Recycling.cs:64) and IsActive would read false.
+            Assert.IsTrue(player.IsActive,
+                "The caller's IAudioPlayer must still be live after two handovers - UpdateInstance re-points " +
+                "it at the incoming player, and the owner of a looping sound has no other handle to hold.");
+            Assert.AreEqual(TargetVolume, player.GetVolume(), VolumeTolerance,
+                "The volume set before the first seam must ride across both handovers, via " +
+                "PlaybackHandoverData.TrackVolume and ReceiveHandover's _trackVolume.Complete.");
+            Assert.AreEqual(0, onEndCount,
+                "characterizes: OnEnd is an end-of-sound callback, not a per-iteration one - BeginHandover " +
+                "transfers the delegate away before the outgoing player's EndPlaying could invoke it.");
+
+            // The real proof that the handle still commands the sound: a handle stranded on the recycled
+            // first player would make this a no-op and the loop would keep running.
+            player.Stop(0f);
+            yield return WaitFrames(3);
+
+            Assert.AreEqual(0, GetActivePlayers(id).Count,
+                "Stop() on the handle must stop the handed-over player and the one already scheduled behind it.");
+            Assert.AreEqual(1, onEndCount,
+                "OnEnd must fire exactly once, at the real end of the sound, no matter how many seams it crossed.");
         }
 
         // 2.3 - a seamless loop's transition time is applied as both the outgoing player's fade-out and the

--- a/Assets/Tests/Runtime/PlaybackLifecycleTests.cs
+++ b/Assets/Tests/Runtime/PlaybackLifecycleTests.cs
@@ -341,5 +341,71 @@ namespace Ami.BroAudio.Tests
             BroAudio.UnPause(BroAudioType.SFX, fadeTime);
             yield return WaitForPlaybackStart(player, "UnPause(type, fadeTime) to resume the AudioSource");
         }
+
+        // Stop(onFinished) - "fade the music out, then load the next scene" - and the one handle shape that
+        // breaks that promise. AudioPlayer.Playback.cs:544 invokes onFinished at the very tail of StopControl,
+        // after the fade-out has run to completion and after EndPlaying() (:531) has already recycled the
+        // player; only the no-fade early-out (:465) fires it synchronously. Fade progress runs on capped
+        // Time.deltaTime, so the fade is kept wide (2s) and the "not yet" half polls across a whole second
+        // rather than sampling at one instant - Unity caps a hitch frame at ~0.333s, which is enough to
+        // swallow a single sample taken shortly after the call.
+        [UnityTest]
+        public IEnumerator Stop_WithOnFinishedCallback_FiresAfterTheFadeButIsDroppedByARecycledHandle()
+        {
+            yield return RequireRealtimeAudioClock();
+
+            const float fadeOut = 2f;
+            bool fired = false;
+
+            SoundID id = NewSound("StopCallbackSfx", BroAudioType.SFX, NewClip(3f));
+            IAudioPlayer player = BroAudio.Play(id);
+            yield return WaitForPlaybackStart(player);
+            yield return WaitFrames(3);
+
+            player.Stop(fadeOut, () => fired = true);
+
+            float stillFadingUntil = Time.realtimeSinceStartup + 1f;
+            while (Time.realtimeSinceStartup < stillFadingUntil)
+            {
+                Assert.IsFalse(fired, "onFinished must not fire while the 2s fade-out is still in flight.");
+                yield return null;
+            }
+
+            Assert.IsTrue(player.IsPlaying,
+                "The voice stays audible for the whole fade - StopControl's fade region runs before the StopMode.Stop switch case.");
+
+            yield return WaitUntilOrTimeout(() => fired, "the fade-out to finish and Stop's onFinished callback to fire", fadeOut + 2f);
+            Assert.IsFalse(player.IsActive,
+                "EndPlaying() runs before onFinished, so the player is already recycled by the time the callback fires.");
+
+            // characterizes: the same call on a handle whose player has already been recycled drops the
+            // callback silently. AudioPlayerInstanceWrapper.cs:45 forwards it as `Instance?.Stop(onFinished)`,
+            // and InstanceWrapper.Instance (Extension/Tools/InstanceWrapper.cs:8) resolves to null once
+            // Recycle() has cleared the backing field, so the null-conditional swallows the entire call -
+            // onFinished is never stored anywhere and never runs. Empty.AudioPlayer's Stop(Action)
+            // (EmptyInstance.cs:49) is an empty body and drops it the same way, so a rejected Play behaves
+            // identically. This is the defect being pinned, not the contract we want: "fade out, then load
+            // the next scene" never loads the scene. See Docs/TEST_FINDINGS.md #41.
+            //
+            // Reading Instance on a recycled wrapper logs through LogInstanceIsNull (gated by
+            // AudioPlayerInstanceWrapper.cs:21), so the warning is silenced exactly as
+            // StaleHandle_AfterRecycle_IsInertNotFatal does - log suppression, not the behavior under test.
+            // The fixture restores RuntimeSetting in TearDown.
+            SoundManager.Instance.Setting.LogAccessRecycledPlayerWarning = false;
+
+            bool firedOnRecycled = false;
+            SoundID recycledId = NewSound("StopCallbackRecycledSfx", BroAudioType.SFX, NewClip(0.2f));
+            IAudioPlayer recycledPlayer = BroAudio.Play(recycledId);
+
+            yield return WaitForPlaybackStart(recycledPlayer);
+            yield return WaitForRecycle(recycledPlayer, "the short clip to finish and the player to recycle");
+
+            Assert.DoesNotThrow(() => recycledPlayer.Stop(() => firedOnRecycled = true),
+                "Stop(onFinished) on a stale handle must never throw.");
+            yield return WaitFrames(3);
+
+            Assert.IsFalse(firedOnRecycled,
+                "characterizes: Stop(onFinished) on a recycled handle is a silent no-op - the callback is dropped, never invoked.");
+        }
     }
 }

--- a/Assets/Tests/Runtime/SchedulingAndMusicTests.cs
+++ b/Assets/Tests/Runtime/SchedulingAndMusicTests.cs
@@ -47,16 +47,41 @@ namespace Ami.BroAudio.Tests
         [UnityTest]
         public IEnumerator SetScheduledStartTime_CalledBeforeQueueDrains_OverridesClipDelay()
         {
+            // The held-voice checks below sample the DSP clock at a point inside the schedule. A machine with no
+            // audio output device runs that clock decoupled from wall time - hundreds of times faster - so a single
+            // frame can carry WaitDspSeconds past the whole schedule and the voice would read as started. The
+            // schedule and the observation share the clock, so a uniformly fast clock is harmless; it is the
+            // per-frame jump that breaks it. AudioClockProbeTests is what stops this ignore from hiding a broken
+            // CI image.
+            yield return RequireRealtimeAudioClock();
+
             AudioEntity entity = NewEntity("DelayVsScheduleSfx", BroAudioType.SFX, NewClip(2f));
             entity.Clips[0].Delay = 5f;
             SoundID id = IdOf(entity);
 
             IAudioPlayer player = BroAudio.Play(id); // only enqueued - SoundManager.LateUpdate hasn't drained it yet
-            double target = AudioSettings.dspTime + 0.3;
+            // 1.5s (was 0.3s): long enough to observe the voice being *held*, not merely to observe it starting.
+            double target = AudioSettings.dspTime + 1.5;
             player.SetScheduledStartTime(target); // SetClipDelayIfNotScheduled will see ScheduledStartTime > 0 and skip the 5s clip.Delay
 
+            // SetScheduledStartTime -> PlayInternal -> SchedulePlayback runs AudioSource.PlayScheduled synchronously,
+            // and PlayScheduled reports isPlaying true from the call, so IsPlaying cannot tell "held" from "started".
+            // Only the playhead can: PlayControl seeds it with
+            // AudioSource.timeSamples = GetSample(audioClip.frequency, _clip.StartPosition) (AudioPlayer.Playback.cs),
+            // and the fixture's clips leave StartPosition at 0, so a held voice reads exactly 0.
+            yield return WaitForPlaybackStart(player, "PlayScheduled to arm the voice immediately");
+            Assert.AreEqual(0, player.AudioSource.timeSamples, "The voice must be held by the explicit schedule, not started at once.");
+
+            // Sample 0.5s into the 1.5s schedule: 1s of decisive window remains - three capped hitch frames
+            // (Time.maximumDeltaTime ~0.333s) wide. Without these two checks the test would still pass if the
+            // schedule were dropped entirely and the voice started immediately.
+            yield return WaitDspSeconds(0.5);
+            Assert.AreEqual(0, player.AudioSource.timeSamples, "Still held 0.5s in - the explicit schedule must not have been ignored.");
+
+            // 3s covers the ~1s of schedule that is left with 2s to spare, yet stays 1.5s short of an
+            // un-overridden 5s clip.Delay (3.5s short of an additive 6.5s), so either regression fails loudly.
             yield return WaitUntilOrTimeout(() => player.AudioSource.timeSamples > 0,
-                "the 0.3s explicit schedule to win over the 5s clip.Delay", 1.5f);
+                "the 1.5s explicit schedule to win over the 5s clip.Delay", 3f);
         }
 
         // 2.5 - SetDelay (ISchedulable.SetDelay) is sugar for SetScheduledStartTime(dspTime + delay), so
@@ -65,15 +90,39 @@ namespace Ami.BroAudio.Tests
         [UnityTest]
         public IEnumerator SetDelay_CalledBeforeQueueDrains_OverridesClipDelayRatherThanAddingToIt()
         {
+            // The held-voice checks below sample the DSP clock at a point inside the schedule. A machine with no
+            // audio output device runs that clock decoupled from wall time - hundreds of times faster - so a single
+            // frame can carry WaitDspSeconds past the whole schedule and the voice would read as started. The
+            // schedule and the observation share the clock, so a uniformly fast clock is harmless; it is the
+            // per-frame jump that breaks it. AudioClockProbeTests is what stops this ignore from hiding a broken
+            // CI image.
+            yield return RequireRealtimeAudioClock();
+
             AudioEntity entity = NewEntity("DelayOverrideSfx", BroAudioType.SFX, NewClip(2f));
             entity.Clips[0].Delay = 5f;
             SoundID id = IdOf(entity);
 
             IAudioPlayer player = BroAudio.Play(id); // only enqueued - SoundManager.LateUpdate hasn't drained it yet
-            player.SetDelay(0.3f); // SetClipDelayIfNotScheduled will see ScheduledStartTime > 0 and skip the 5s clip.Delay
+            player.SetDelay(1.5f); // SetClipDelayIfNotScheduled will see ScheduledStartTime > 0 and skip the 5s clip.Delay
 
+            // 1.5s (was 0.3s) so the held voice can be observed, not just its eventual start. SetDelay resolves to
+            // SetScheduledStartTime(dspTime + delay), which arms AudioSource.PlayScheduled synchronously and makes
+            // isPlaying true right away - so the playhead, not IsPlaying, is the only signal that says "held".
+            // PlayControl seeds it with GetSample(audioClip.frequency, _clip.StartPosition) (AudioPlayer.Playback.cs)
+            // and the fixture's clips leave StartPosition at 0, so a held voice reads exactly 0.
+            yield return WaitForPlaybackStart(player, "PlayScheduled to arm the voice immediately");
+            Assert.AreEqual(0, player.AudioSource.timeSamples, "The voice must be held by the explicit SetDelay, not started at once.");
+
+            // Sample 0.5s into the 1.5s delay: 1s of decisive window remains - three capped hitch frames
+            // (Time.maximumDeltaTime ~0.333s) wide. Without these two checks the test would still pass if the
+            // delay were dropped entirely and the voice started immediately.
+            yield return WaitDspSeconds(0.5);
+            Assert.AreEqual(0, player.AudioSource.timeSamples, "Still held 0.5s in - the explicit SetDelay must not have been ignored.");
+
+            // 3s covers the ~1s of delay that is left with 2s to spare, yet stays 1.5s short of an un-overridden
+            // 5s clip.Delay (3.5s short of an additive 6.5s), so either regression fails loudly.
             yield return WaitUntilOrTimeout(() => player.AudioSource.timeSamples > 0,
-                "the 0.3s explicit SetDelay to win over the 5s clip.Delay", 1.5f);
+                "the 1.5s explicit SetDelay to win over the 5s clip.Delay", 3f);
         }
 
         // 2.7 - the documented quirk: SetScheduledStartTime on an already-playing source pauses it
@@ -84,7 +133,10 @@ namespace Ami.BroAudio.Tests
             yield return RequireRealtimeAudioClock();
 
             int onPauseCount = 0;
-            SoundID id = NewSound("RescheduleWhilePlayingSfx", BroAudioType.SFX, NewClip(3f));
+            // 6s clip (was 3s): the stall does not push the end out - _playbackEndDspTime is fixed when PlayControl
+            // resolves the timing and SetScheduledStartTime never recalculates it - so the clip has to outlast the
+            // 2s stall plus the resume observation, or the player would end playback while still stalled.
+            SoundID id = NewSound("RescheduleWhilePlayingSfx", BroAudioType.SFX, NewClip(6f));
             IAudioPlayer player = BroAudio.Play(id);
             player.OnPause(_ => onPauseCount++);
 
@@ -92,7 +144,7 @@ namespace Ami.BroAudio.Tests
             yield return WaitFrames(3);
 
             double now = AudioSettings.dspTime;
-            player.SetScheduledStartTime(now + 0.4); // reschedule while already playing
+            player.SetScheduledStartTime(now + 2.0); // reschedule while already playing - stalls the source for 2s
 
             // characterizes: IAudioPlayer.IsPlaying/IsActive stay true and OnPause never fires - the
             // pause is only visible on the raw AudioSource, per the "left as is" comment in Scheduling.cs.
@@ -101,14 +153,18 @@ namespace Ami.BroAudio.Tests
             Assert.AreEqual(0, onPauseCount, "OnPause must not fire for a reschedule-induced stall - only Pause()/StopMode.Pause does that.");
 
             int stalledSamples = player.AudioSource.timeSamples;
-            yield return WaitDspSeconds(0.2);
+            // Sample a full second into the 2s stall (was 0.2s into a 0.4s stall - a 0.2s margin, thinner than one
+            // capped hitch frame at Time.maximumDeltaTime ~0.333s): the playhead is now proven frozen across a whole
+            // second, and a whole second of stall still remains, so no hitch can carry this check past the resume.
+            yield return WaitDspSeconds(1.0);
             Assert.AreEqual(stalledSamples, player.AudioSource.timeSamples,
                 "characterizes: the AudioSource playhead stalls while paused-for-reschedule, though nothing in IAudioPlayer reflects it.");
             Assert.IsTrue(player.IsPlaying, "IsPlaying must still read true while the source sits stalled.");
             Assert.AreEqual(0, onPauseCount, "OnPause still must not have fired while the stall is in progress.");
 
+            // ~1s of stall is left; 2s keeps a full second of slack for the resume to be observed.
             yield return WaitUntilOrTimeout(() => player.AudioSource.timeSamples > stalledSamples,
-                "the playhead to resume advancing once the rescheduled dspTime arrives", 1f);
+                "the playhead to resume advancing once the rescheduled dspTime arrives", 2f);
         }
 
         // 2.7 - SetScheduledEndTime is an absolute-time contract: it stops playback at the given
@@ -120,14 +176,17 @@ namespace Ami.BroAudio.Tests
             IAudioPlayer player = BroAudio.Play(id);
             yield return WaitForPlaybackStart(player);
 
-            double target = AudioSettings.dspTime + 1.0;
+            // 2s (was 1s) so the "still active" sample below lands a full second short of the end rather than 0.3s,
+            // which was thinner than one capped hitch frame (Time.maximumDeltaTime ~0.333s).
+            double target = AudioSettings.dspTime + 2.0;
             player.SetScheduledEndTime(target);
 
-            yield return WaitDspSeconds(0.7);
-            Assert.IsTrue(player.IsActive, "Player must still be active shortly before the explicit end time (clip is 4s long).");
+            yield return WaitDspSeconds(1.0);
+            Assert.IsTrue(player.IsActive, "Player must still be active a full second before the explicit end time (clip is 4s long).");
 
-            // Margin: one MixerWarmUpTime-ish window (0.3s) past the 1s target to absorb frame granularity.
-            yield return WaitUntilOrTimeout(() => !player.IsActive, "playback to end at the explicit scheduled end time, not the clip's natural 4s length", 1.3f);
+            // 2s past the sample point is 1s past the 2s target - three capped hitch frames of slack - and still
+            // ~1s short of the clip's natural 4s end, so an ignored explicit end still times out here.
+            yield return WaitUntilOrTimeout(() => !player.IsActive, "playback to end at the explicit scheduled end time, not the clip's natural 4s length", 2f);
         }
 
         // 2.9 - SetPitch mid-play recomputes the *derived* end time from the actual playhead
@@ -157,19 +216,28 @@ namespace Ami.BroAudio.Tests
         [UnityTest]
         public IEnumerator SetPitch_AfterExplicitScheduledEndTime_DoesNotRescaleEndTime()
         {
-            SoundID id = NewSound("PitchVsExplicitEndSfx", BroAudioType.SFX, NewClip(4f));
+            // 6s clip (was 4s): what this test has to rule out is not the clip's natural end but the *recalculated*
+            // one - if RecalculateScheduledEndTime stopped honouring _isEndTimeDerivedFromClip it would re-derive
+            // the end from the playhead as clipLength / pitch, i.e. ~4s here (later than the explicit end, not
+            // sooner). At 4s the clip put that regression at ~2.7s, too close to a 2s explicit end to separate the
+            // two by a whole second.
+            SoundID id = NewSound("PitchVsExplicitEndSfx", BroAudioType.SFX, NewClip(6f));
             IAudioPlayer player = BroAudio.Play(id);
             yield return WaitForPlaybackStart(player);
 
-            double target = AudioSettings.dspTime + 1.0;
+            // 2s (was 1s) so the "still active" sample below lands a full second short of the end rather than 0.3s,
+            // which was thinner than one capped hitch frame (Time.maximumDeltaTime ~0.333s).
+            double target = AudioSettings.dspTime + 2.0;
             player.SetScheduledEndTime(target);
-            player.SetPitch(1.5f); // must not shorten the explicit 1s end time
+            player.SetPitch(1.5f); // must not move the explicit 2s end time (a recalculation would push it out to ~4s)
 
-            yield return WaitDspSeconds(0.7);
-            Assert.IsTrue(player.IsActive, "Player must still be active shortly before the explicit end time even after a pitch change.");
+            yield return WaitDspSeconds(1.0);
+            Assert.IsTrue(player.IsActive, "Player must still be active a full second before the explicit end time even after a pitch change.");
 
+            // 2s past the sample point is 1s past the 2s target, and still ~1s short of the ~4s end a pitch-driven
+            // recalculation would have produced - decisive by a full second in both directions.
             yield return WaitUntilOrTimeout(() => !player.IsActive,
-                "playback to end at the still-unmoved explicit end time (~1s), not sooner from the pitch change", 1.3f);
+                "playback to end at the still-unmoved explicit end time (~2s), not at the pitch-rescaled ~4s", 2f);
         }
 
         // 2.8 - Default/OnlyFadeOut transitions are sequential: PlayControl explicitly waits on

--- a/Assets/Tests/Runtime/SelectionStateAndDecoratorTests.cs
+++ b/Assets/Tests/Runtime/SelectionStateAndDecoratorTests.cs
@@ -288,9 +288,12 @@ namespace Ami.BroAudio.Tests
             // (Effect.cs:78), so 0.2 becomes ~-13.98dB.
             //
             // A non-zero fade is deliberate. With fadeTime 0 the tween drains synchronously inside
-            // StartCoroutine (the finding #17 regression documented in AudioEffectTests), which lands the
-            // ducked value *before* SetEffectTrackParameter's own SwitchMainTrackMode(true) overwrites
-            // Main_Dominated with FullDecibelVolume - see Docs/TEST_FINDINGS.md #43.
+            // StartCoroutine - AudioEffectTests.SetEffect_WithDefaultZeroFade_ThenForSeconds_AutoResetsWithoutThrowing
+            // already pins that ("a zero fadeTime still applies the parameter right away"), and the bug it
+            // came from is Docs/FIXED_ISSUES.md #17 - that file's numbering, not TEST_FINDINGS'. A zero fade
+            // would therefore land the ducked value *before* SetEffectTrackParameter's own
+            // SwitchMainTrackMode(true) overwrites Main_Dominated with FullDecibelVolume - see
+            // Docs/TEST_FINDINGS.md #43.
             dominator.QuietOthers(othersVolume, 0.1f);
 
             yield return WaitUntilOrTimeout(() =>
@@ -337,6 +340,107 @@ namespace Ami.BroAudio.Tests
             StringAssert.StartsWith(BroName.GenericTrackName, latePlayer.AudioSource.outputAudioMixerGroup.name,
                 "Decorating after play started must leave the player on its generic track - TrackType is only " +
                 "consulted by SetupAudioTrack, which has already run. Nothing re-routes it.");
+        }
+
+        // 3.6 x 2.2 - the two crossed: a dominator that loops. Looping is implemented by handing the sound
+        // from one player to the next rather than by AudioSource.loop (LoopHandoverTests covers the handover
+        // itself), and AudioPlayerInstanceWrapper.UpdateInstance moves the decorators onto the incoming
+        // player (AudioPlayerInstanceWrapper.cs:144-151), so IsDominator (AudioPlayer.cs:40) reads true again
+        // on the far side of a seam and the ducking never lets go. The *track* does not follow, and the
+        // reason is pure ordering:
+        //
+        //   ScheduleNextPlayback's wait gate releases one warm-up time (0.1s) BEFORE the seam
+        //   (AudioPlayer.Playback.cs:334-338) and calls RequestNextPlayer (:365), which runs
+        //   SoundManager.ScheduleNextPlayback -> ReceiveHandover -> PlayInternal
+        //   (SoundManager.Playback.cs:119-125, AudioPlayer.Playback.cs:402) synchronously; PlayControl then
+        //   runs straight through SetupAudioTrack (:118) with nothing yielding before it. The decorators
+        //   only arrive later, at BeginHandover (:229 -> :375), so SetupAudioTrack reads IsDominator ==
+        //   false on the incoming player and takes a generic track from the pool.
+        //
+        // The incoming player therefore lands under Main - which its own QuietOthers has just muted, routing
+        // everything audible through Main_Dominated at the ducked level. A looping dominator ducks itself
+        // from the first seam onward, without the caller doing anything wrong. This is finding #42's
+        // self-ducking arriving on its own, on a handle the caller never let go of. See
+        // Docs/TEST_FINDINGS.md #44.
+        [UnityTest]
+        public IEnumerator Play_LoopingDominator_KeepsDuckingAcrossASeamButTheIncomingPlayerTakesAGenericTrack()
+        {
+            yield return RequireRealtimeAudioClock();
+
+            const float ClipSeconds = 1f;
+            const float OthersVolume = 0.2f;
+            AudioEntity entity = NewEntity("LoopingDominatorSfx", BroAudioType.SFX, NewClip(ClipSeconds));
+            TestAudioLibrary.SetPrivateField(entity, "Loop", true);
+            SoundID id = IdOf(entity);
+
+            // Chained in the same frame as Play, as in Play_AsDominatorInTheSameFrame_* above - the only way
+            // even the first player reaches a Dominator track.
+            IAudioPlayer player = BroAudio.Play(id);
+            IPlayerEffect dominator = player.AsDominator();
+            yield return WaitForPlaybackStart(player, "the looping dominator to start playing");
+
+            AudioPlayer firstInstance = InstanceOf(player);
+            Assert.IsNotNull(firstInstance, "Precondition: the handle should resolve to a live player.");
+            StringAssert.StartsWith(BroName.DominatorTrackName, player.AudioSource.outputAudioMixerGroup.name,
+                "Precondition: the first player of a same-frame dominator is routed to a pooled Dominator track.");
+
+            // Non-zero fade, for the ordering reason spelled out in the same-frame test above (finding #43).
+            dominator.QuietOthers(OthersVolume, 0.1f);
+            yield return WaitUntilOrTimeout(() =>
+            {
+                SoundManager.Instance.AudioMixer.GetFloat(BroName.MainDominatedTrackName, out float v);
+                return Mathf.Abs(v - OthersVolume.ToDecibel()) < DecibelTolerance;
+            }, "Main_Dominated to reach the requested others-volume in decibels, well before the first seam", 2f);
+
+            // The seam itself. UpdateInstance re-points the caller's wrapper at the incoming player, so the
+            // handle resolving to a *different* AudioPlayer is the handover - no dsp arithmetic needed to
+            // spot it, unlike the clock-derived seams in LoopHandoverTests.
+            yield return WaitUntilOrTimeout(() =>
+            {
+                AudioPlayer current = InstanceOf(player);
+                return current && current != firstInstance;
+            }, "the loop to hand over to a second player, with the handle following it", ClipSeconds + 4f);
+
+            // Nothing below yields: every assertion has to describe the same moment, just past the seam.
+            // MonitorVirtualTrack can hand a Generic track back after half a second of virtualization
+            // (AudioPlayer.VirtualTrack.cs:24-50), and the next seam is only one clip away.
+            Assert.IsTrue(player.IsPlaying, "The looping sound must still be audible on the incoming player.");
+
+            // characterizes: AudioPlayer.TransferDecorators/SetDecorators (AudioPlayer.cs:363-373), driven by
+            // AudioPlayerInstanceWrapper.UpdateInstance (:144-151). The list is moved off the outgoing player
+            // first, so its Recycle() no longer sees it (AudioPlayer.Recycling.cs:55-62) and never recycles
+            // the decorator out from under the incoming one.
+            List<AudioPlayerDecorator> decorators = GetDecorators(player);
+            Assert.IsNotNull(decorators, "The decorator list must have been transferred to the incoming player.");
+            Assert.IsTrue(decorators.Exists(d => d is DominatorPlayer),
+                "The DominatorPlayer decorator must survive the handover - it is the caller's only dominator handle.");
+
+            // characterizes: and yet the routing does not follow the decorator. SetupAudioTrack already ran
+            // on this player, one warm-up time before the decorator arrived, and read IsDominator == false.
+            StringAssert.StartsWith(BroName.GenericTrackName, player.AudioSource.outputAudioMixerGroup.name,
+                "A looping dominator's incoming player takes a generic track: the decorator is transferred at " +
+                "BeginHandover, which runs after that player's SetupAudioTrack has already chosen a track.");
+
+            // characterizes: the duck itself is untouched by the seam. DominatorPlayer.PlayerIsPlaying
+            // (DominatorPlayer.cs:77) is the decorator's own IsActive (AudioPlayerInstanceWrapper.cs:31),
+            // and the decorator is re-pointed at the incoming player before the outgoing one is recycled, so
+            // the .While() waitable in TweakTrackParameter (EffectAutomationHelper.cs:213-227) never observes
+            // a false and never runs its auto-reset. Main stays muted - and now mutes the dominator too.
+            Assert.IsTrue(SoundManager.Instance.AudioMixer.GetFloat(BroName.MainTrackName, out float mainAfterSeam));
+            Assert.AreEqual(AudioConstant.MinDecibelVolume, mainAfterSeam, DecibelTolerance,
+                "The dominator's own duck must still be in effect after the seam.");
+            SoundManager.Instance.AudioMixer.GetFloat(BroName.MainDominatedTrackName, out float dominatedAfterSeam);
+            Assert.AreEqual(OthersVolume.ToDecibel(), dominatedAfterSeam, DecibelTolerance,
+                "Main_Dominated must still carry the ducked level - which is now the level the loop plays at.");
+
+            // Same restore-and-assert tail as the same-frame test: Stop is what ends the .While() waitable,
+            // and leaving Main at MinDecibelVolume would mute every later test in the run.
+            player.Stop(0f);
+            yield return WaitUntilOrTimeout(() =>
+            {
+                SoundManager.Instance.AudioMixer.GetFloat(BroName.MainTrackName, out float v);
+                return Mathf.Abs(v - AudioConstant.FullDecibelVolume) < DecibelTolerance;
+            }, "Main to return to full volume once the looping dominator stops", 3f);
         }
 
         #endregion
@@ -397,9 +501,15 @@ namespace Ami.BroAudio.Tests
 
         #endregion
 
+        /// <summary>
+        /// The AudioPlayer a caller's handle currently resolves to, or null once it has been recycled.
+        /// A looping handle changes what this returns at every seam - that is what UpdateInstance does.
+        /// </summary>
+        private static AudioPlayer InstanceOf(IAudioPlayer player) => (AudioPlayer)(AudioPlayerInstanceWrapper)player;
+
         private static List<AudioPlayerDecorator> GetDecorators(IAudioPlayer player)
         {
-            AudioPlayer instance = (AudioPlayer)(AudioPlayerInstanceWrapper)player;
+            AudioPlayer instance = InstanceOf(player);
             FieldInfo field = typeof(AudioPlayer).GetField("_decorators", BindingFlags.NonPublic | BindingFlags.Instance);
             Assert.IsNotNull(field, "Reflection: AudioPlayer._decorators not found - renamed? " +
                 "Update SelectionStateAndDecoratorTests.cs.GetDecorators (also guarded by the canary in SerializedTransportTests.cs).");

--- a/Assets/Tests/Runtime/SelectionStateAndDecoratorTests.cs
+++ b/Assets/Tests/Runtime/SelectionStateAndDecoratorTests.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using Ami.BroAudio.Data;
 using Ami.BroAudio.Runtime;
 using Ami.BroAudio.Tools;
+using Ami.Extension;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -18,6 +19,10 @@ namespace Ami.BroAudio.Tests
     /// </summary>
     public class SelectionStateAndDecoratorTests : BroAudioTestFixture
     {
+        // dB values make a round trip through the mixer, so they need a looser tolerance than a linear
+        // comparison would - the same split VolumePitchMixerTests documents.
+        private const float DecibelTolerance = 0.1f;
+
         #region 3.5 Clip-selection state lives on the AudioEntity, not the player
 
         [UnityTest]
@@ -251,6 +256,87 @@ namespace Ami.BroAudio.Tests
             LogAssert.Expect(LogType.Warning, new Regex("othersVol should be less than 1 and greater than 0"));
             dominator.QuietOthers(0f, 0f);
             yield return WaitFrames(2);
+        }
+
+        // AudioPlayer.SetupAudioTrack (AudioPlayer.Playback.cs:255-262) is the only place TrackType becomes
+        // Dominator, and it reads IsDominator - i.e. whether a DominatorPlayer decorator is already attached -
+        // at play time, when SoundManager.LateUpdate drains the queue. AsDominator() must therefore be chained
+        // in the same frame as Play() to reach the dominator track at all. Every other dominator test in this
+        // file decorates *after* WaitForPlaybackStart, so none of them exercises this routing; see
+        // Play_ThenAsDominatorAfterPlaybackStarted_StaysOnAGenericTrack below for what those tests actually run.
+        [UnityTest]
+        public IEnumerator Play_AsDominatorInTheSameFrame_RoutesToADominatorTrackAndDucksTheMainTrack()
+        {
+            const float othersVolume = 0.2f;
+            SoundID dominatorId = NewSound("SameFrameDominatorSfx", BroAudioType.SFX, NewClip(4f));
+
+            // Chained before the queue drains, so IsDominator is true by the time SetupAudioTrack runs.
+            IAudioPlayer dominatorPlayer = BroAudio.Play(dominatorId);
+            IPlayerEffect dominator = dominatorPlayer.AsDominator();
+            yield return WaitForPlaybackStart(dominatorPlayer, "the dominator to start playing");
+
+            StringAssert.StartsWith(BroName.DominatorTrackName, dominatorPlayer.AudioSource.outputAudioMixerGroup.name,
+                "A player decorated as a dominator before the queue drained must be routed to a pooled Dominator track, " +
+                "not to a generic Track* group under Main - otherwise it is filtered by its own QuietOthers/LowPassOthers.");
+
+            // QuietOthers writes through EffectAutomationHelper, whose GetEffectParameterName maps a
+            // dominator Volume effect to Main_Dominated (:315-329) - never to Main. Main is muted outright:
+            // SwitchMainTrackMode(true) does ChangeChannel(Main -> Main_Dominated), and ChangeChannel
+            // (AudioExtension.cs:148-152) sets the "from" parameter to MinDecibelVolume and the "to"
+            // parameter to the passed target. So the ducked level lands on Main_Dominated, and it is
+            // Effect.Value that converts it: for EffectType.Volume the setter stores value.ToDecibel()
+            // (Effect.cs:78), so 0.2 becomes ~-13.98dB.
+            //
+            // A non-zero fade is deliberate. With fadeTime 0 the tween drains synchronously inside
+            // StartCoroutine (the finding #17 regression documented in AudioEffectTests), which lands the
+            // ducked value *before* SetEffectTrackParameter's own SwitchMainTrackMode(true) overwrites
+            // Main_Dominated with FullDecibelVolume - see Docs/TEST_FINDINGS.md #43.
+            dominator.QuietOthers(othersVolume, 0.1f);
+
+            yield return WaitUntilOrTimeout(() =>
+            {
+                SoundManager.Instance.AudioMixer.GetFloat(BroName.MainDominatedTrackName, out float v);
+                return Mathf.Abs(v - othersVolume.ToDecibel()) < DecibelTolerance;
+            }, "Main_Dominated to reach the requested others-volume in decibels", 2f);
+
+            Assert.IsTrue(SoundManager.Instance.AudioMixer.GetFloat(BroName.MainTrackName, out float mainWhileDominating));
+            Assert.AreEqual(AudioConstant.MinDecibelVolume, mainWhileDominating, DecibelTolerance,
+                "While a dominator is active the plain Main channel is muted outright and everything audible is " +
+                "routed through Main_Dominated, which carries the ducked level.");
+
+            // The restore is not teardown's job: TweakTrackParameter calls SwitchMainTrackMode(false) once its
+            // .While(PlayerIsPlaying) waitable finishes, which is what returns Main to full volume. Asserting it
+            // here also keeps this test from leaving a muted Main behind for every later test in the run.
+            dominatorPlayer.Stop(0f);
+            yield return WaitUntilOrTimeout(() =>
+            {
+                SoundManager.Instance.AudioMixer.GetFloat(BroName.MainTrackName, out float v);
+                return Mathf.Abs(v - AudioConstant.FullDecibelVolume) < DecibelTolerance;
+            }, "Main to return to full volume once the dominator stops", 3f);
+        }
+
+        // characterizes: AsDominator() after playback has started attaches the decorator but cannot move the
+        // player - SetupAudioTrack already ran and already took a generic track from the pool. The player stays
+        // under Main, which means it filters and ducks *itself* along with everything else. This is the
+        // configuration LowPassOthers_MovesDominatorLowPassParameter_* and its HighPass twin above actually run:
+        // they pass in both configurations because they only watch the Main_LowPass/Main_HighPass parameter move,
+        // which is true either way. See Docs/TEST_FINDINGS.md #42.
+        [UnityTest]
+        public IEnumerator Play_ThenAsDominatorAfterPlaybackStarted_StaysOnAGenericTrack()
+        {
+            SoundID lateId = NewSound("LateDominatorSfx", BroAudioType.SFX, NewClip(3f));
+            IAudioPlayer latePlayer = BroAudio.Play(lateId);
+            yield return WaitForPlaybackStart(latePlayer, "the player to start playing");
+
+            StringAssert.StartsWith(BroName.GenericTrackName, latePlayer.AudioSource.outputAudioMixerGroup.name,
+                "Precondition: an undecorated player starts on a pooled generic track.");
+
+            latePlayer.AsDominator();
+            yield return WaitFrames(2);
+
+            StringAssert.StartsWith(BroName.GenericTrackName, latePlayer.AudioSource.outputAudioMixerGroup.name,
+                "Decorating after play started must leave the player on its generic track - TrackType is only " +
+                "consulted by SetupAudioTrack, which has already run. Nothing re-routes it.");
         }
 
         #endregion

--- a/Assets/Tests/Runtime/SpectrumAnalyzerTests.cs
+++ b/Assets/Tests/Runtime/SpectrumAnalyzerTests.cs
@@ -23,11 +23,12 @@ namespace Ami.BroAudio.Tests
     /// exactly zero or merely near it, so that one test asserts on both outcomes.
     /// </para>
     /// <para>
-    /// One test plays a real tone end to end. It is the only one whose result depends on the engine actually
-    /// producing spectrum data, so it says so and ignores itself when the buffer never leaves zero. Every
-    /// test that needs playback to survive more than a frame first calls RequireRealtimeAudioClock: without
-    /// an audio output device the DSP clock runs hundreds of times faster than wall time and a clip is over
-    /// before the analyzer ever sees it.
+    /// Two tests play a real tone end to end - the band-coverage check and the Weighted pin, which needs a
+    /// band carrying real energy for a weighting to have anything to act on. They are the only ones whose
+    /// result depends on the engine actually producing spectrum data, so they say so and ignore themselves
+    /// when the buffer never leaves zero. Every test that needs playback to survive more than a frame first
+    /// calls RequireRealtimeAudioClock: without an audio output device the DSP clock runs hundreds of times
+    /// faster than wall time and a clip is over before the analyzer ever sees it.
     /// </para>
     /// </summary>
     public class SpectrumAnalyzerTests : BroAudioTestFixture
@@ -363,37 +364,6 @@ namespace Ami.BroAudio.Tests
             Assert.Greater(smoothed.Bands[0].DecibelVolume, -40f,
                 "An 80dB difference over a smoothing of 4000 scales the step down 50x, so the smoothed band is nowhere near the floor yet.");
         }
-        // TEST_FINDINGS #40. Every Band carries a serialized, inspector-drawn "Weighted" value that
-        // UpdateSpectrum never reads, so two analyzers that differ only in it produce the same numbers. The
-        // rise is deliberately slow enough that both are still mid-travel when they are compared - two bands
-        // resting on the same target would agree whether or not the field did anything.
-        [UnityTest]
-        public IEnumerator Update_BandWeighting_HasNoEffectOnTheBandOutput()
-        {
-            yield return RequireRealtimeAudioClock();
-            IAudioPlayer player = PlaySilence();
-            yield return WaitForPlaybackStart(player);
-
-            const float StartDecibel = -200f;
-            SpectrumAnalyzer unweighted = NewAnalyzer(new[] { 1000f }, attack: 2000);
-            SpectrumAnalyzer weighted = NewAnalyzer(new[] { 1000f }, attack: 2000);
-            yield return WaitForStart(unweighted);
-            yield return WaitForStart(weighted);
-            TestAudioLibrary.SetPrivateField(unweighted.Bands[0], SpectrumAnalyzer.Band.NameOf.Weighted, 1f);
-            TestAudioLibrary.SetPrivateField(weighted.Bands[0], SpectrumAnalyzer.Band.NameOf.Weighted, 20f);
-            unweighted.SetSource(player);
-            weighted.SetSource(player);
-
-            PinBandTo(unweighted.Bands[0], StartDecibel);
-            PinBandTo(weighted.Bands[0], StartDecibel);
-
-            yield return new WaitForSeconds(0.5f); // a frame-clock ramp, so wall time is the right clock
-
-            Assert.Greater(unweighted.Bands[0].DecibelVolume, StartDecibel, "Precondition: the bands are mid-rise, not parked on a shared target.");
-            Assert.Less(unweighted.Bands[0].DecibelVolume, AudioConstant.MinDecibelVolume, "Precondition: neither band has reached the floor yet.");
-            Assert.AreEqual(unweighted.Bands[0].DecibelVolume, weighted.Bands[0].DecibelVolume, 0.5f,
-                "Characterizes TEST_FINDINGS #40: a band's Weighted field is written by the inspector and read by nothing.");
-        }
         #endregion
 
         #region Band ranges
@@ -483,9 +453,48 @@ namespace Ami.BroAudio.Tests
                 "The normalized amplitude a meter binds to must rise with the decibel value.");
         }
 
+        // TEST_FINDINGS #40. Every Band carries a serialized, inspector-drawn "Weighted" value that
+        // UpdateSpectrum never reads, so two analyzers that differ only in it produce the same numbers.
+        // Driven by the tone rather than by silence deliberately: on an all-zero spectrum the obvious fix -
+        // scaling the metered amplitude by the weight - would still leave the two bands identical, because
+        // 0 * 1 == 0 * 20, and the pin would survive the very change it exists to catch. Metering a band
+        // that carries real energy, any use of the field at all pulls the two readings apart.
+        [UnityTest]
+        public IEnumerator Update_BandWeighting_HasNoEffectOnTheBandOutput()
+        {
+            yield return RequireRealtimeAudioClock();
+            SoundID id = NewSound("WeightedSpectrumSfx", BroAudioType.SFX, NewClip(20f)); // NewClip is a 440Hz sine
+            IAudioPlayer player = BroAudio.Play(id);
+            yield return WaitForPlaybackStart(player);
+
+            // One 10Hz-1kHz band - the window the test above proves the 440Hz tone lights up.
+            SpectrumAnalyzer unweighted = NewAnalyzer(new[] { 1000f }, attack: 100);
+            SpectrumAnalyzer weighted = NewAnalyzer(new[] { 1000f }, attack: 100);
+            yield return WaitForStart(unweighted);
+            yield return WaitForStart(weighted);
+            TestAudioLibrary.SetPrivateField(unweighted.Bands[0], SpectrumAnalyzer.Band.NameOf.Weighted, 1f);
+            TestAudioLibrary.SetPrivateField(weighted.Bands[0], SpectrumAnalyzer.Band.NameOf.Weighted, 20f);
+            unweighted.SetSource(player);
+            weighted.SetSource(player);
+
+            yield return WaitForSpectrumData(unweighted);
+            yield return WaitUntilOrTimeout(() => unweighted.Bands[0].DecibelVolume > AudioConstant.MinDecibelVolume + 20f,
+                "the tone's own band to rise well clear of the floor", 3f);
+            // Both bands climb from the floor under the same 20dB-per-100ms attack, so half a second puts
+            // them past the ramp and onto the tone's own level, which each then re-snaps to every frame -
+            // the state in which a weight applied to one of them has nothing left to hide behind.
+            yield return new WaitForSeconds(0.5f); // a frame-clock ramp, so wall time is the right clock
+
+            Assert.Greater(weighted.Bands[0].DecibelVolume, AudioConstant.MinDecibelVolume + 20f,
+                "Precondition: both analyzers are metering the tone, not resting on a floor where any weighting would cancel out.");
+            Assert.AreEqual(unweighted.Bands[0].DecibelVolume, weighted.Bands[0].DecibelVolume, 0.5f,
+                "Characterizes TEST_FINDINGS #40: a band's Weighted field is written by the inspector and read by nothing - "
+                + "a 20x weight on a band metering a real tone moves its output by less than half a dB, which is to say not at all.");
+        }
+
         /// <summary>
         /// Ignores the calling test unless the engine actually fills the spectrum buffer. Everything else in
-        /// this file is written to hold on an all-zero spectrum; this is the one assertion that cannot be.
+        /// this file is written to hold on an all-zero spectrum; the two tone-driven tests cannot be.
         /// </summary>
         private static IEnumerator WaitForSpectrumData(SpectrumAnalyzer analyzer, float timeout = 2f)
         {

--- a/Assets/Tests/Runtime/VolumePitchMixerTests.cs
+++ b/Assets/Tests/Runtime/VolumePitchMixerTests.cs
@@ -58,6 +58,31 @@ namespace Ami.BroAudio.Tests
             BroAudio.SetVolume(BroAudioType.SFX, 0.4f, 0f);
             yield return WaitFrames(1);
             Assert.AreEqual(0.5f * 0.4f, player.GetVolume(), LinearTolerance, "Per-BroAudioType volume should further multiply the same linear product (0.5 * 0.4).");
+
+            // Everything above reads the library's own bookkeeping - the *inputs* to the mixer write - so a
+            // broken UpdateVolume would still pass. What the listener hears is
+            // AudioPlayer.UpdateVolume (AudioPlayer.Volume.cs:99-103): it writes
+            // (_clipVolume * _trackVolume * _audioTypeVolume).ToDecibel() through TrySetMixerDecibelVolume
+            // to VolumeParaName, and only falls back to AudioSource.volume when there is no mixer/track.
+            // Read the mixer back so the composition rule is proven at the output, not just at the input.
+            //
+            // VolumeParaName (AudioPlayer.cs:72) is GetSendParaName() while the player is routed through a
+            // track effect, and GetCurrentTrackName() - the output group's own name - otherwise. This is a
+            // plain SFX with no effect set, so the group's name is the right parameter here; it would NOT be
+            // for a player under SetEffect, which writes to "<track>_Effect" instead.
+            Assert.IsNotNull(player.AudioSource.outputAudioMixerGroup, "The player must still hold a pooled track for its volume parameter to be exposed.");
+
+            // A fixed frame wait is enough: TrySetMixerDecibelVolume only defers through DelaySetMixerVolume
+            // while Mixer.WaitForAudioMixerInitialization is non-null, and SoundManager.Start (SoundManager.cs:126)
+            // nulls it on the first Play Mode frame - long before the fixture hands a test a live manager - so
+            // SetVolume writes to the mixer synchronously.
+            Assert.IsTrue(SoundManager.Instance.AudioMixer.GetFloat(player.AudioSource.outputAudioMixerGroup.name, out float db));
+
+            // Log10(0.2) * 20 = -13.98 dB. TrySetMixerDecibelVolume then applies ClampDecibel(true), whose
+            // range is [MinDecibelVolume, MaxDecibelVolume] = [-80, 20], so 0.2 passes through untouched and
+            // the expected value stays the plain conversion. dB needs the looser tolerance because it carries
+            // both the log conversion and the mixer round-trip.
+            Assert.AreEqual((0.5f * 0.4f).ToDecibel(), db, DecibelTolerance, "The composed linear product must reach the track's exposed mixer parameter in decibels - GetVolume() alone is only the input to that write.");
         }
 
         [UnityTest]

--- a/Docs/TEST_FINDINGS.md
+++ b/Docs/TEST_FINDINGS.md
@@ -30,6 +30,9 @@ Findings 1-7, 15-20, 28, 30 and 33 have since been fixed and moved to
 | 38 | MonoComponent / SpectrumAnalyzer | Whether the serialized `SoundSource` is polled is decided once, in `Start` | Open, characterized |
 | 39 | MonoComponent / SpectrumAnalyzer | A band narrower than one FFT bin makes RMS/Average divide by zero, and the band runs away to one end of the scale | Open, characterized |
 | 40 | MonoComponent / SpectrumAnalyzer | Every band draws a `Weighted` field in the inspector that the runtime never reads | Open, characterized |
+| 41 | Playback / Stop | `Stop(onFinished)` on a recycled handle drops the callback silently | Open, characterized |
+| 42 | Decorators / Dominator | `AsDominator()` after playback started cannot re-route the player, so it filters itself | Open, characterized |
+| 43 | Decorators / Dominator | `QuietOthers` with a zero fade time is overwritten by `SwitchMainTrackMode`, so nothing ducks | Open, suspected |
 
 ---
 
@@ -251,6 +254,20 @@ Two smaller consequences:
   at runtime has no effect even on the polling interval.
 - The routine is testable only by back-dating `_loadedEntityLastPlayedTime`, which is what
   `AddressablesTests` does — waiting out a hardcoded 60 seconds is not viable in a suite.
+
+It is in fact stronger than "testable only by back-dating": **nothing in production ever adds a key to that
+dictionary**. `UpdateLoadedEntityLastPlayedTime` is guarded by `if (_loadedEntityLastPlayedTime.ContainsKey(id))`,
+and all three of its call sites intend to *register* the entity on load. The only other writes are the refresh
+inside the routine, which iterates keys that already exist, and the `Remove` after unloading. So the dictionary
+stays empty for the life of the player and the auto-unload feature never fires at all; the tests work only
+because `BackDateLastPlayedTime`'s indexer write is what registers the entity in the first place. That is
+arguably the more severe half of this finding and is not separately pinned.
+
+Status: Open, characterized. Pinned by
+`AddressablesTests.CleanupRoutine_WithTheUnloadDelaySetToFiveSeconds_KeepsTheEntityLoadedAnyway`, which asks for
+a 5-second unload delay, lets the entity idle 30 seconds, and asserts it is still loaded.
+`AddressablesTests.CleanupRoutine_WhenAnEntityHasBeenIdleLongEnough_ReleasesItsAssets` covers the other half —
+that the routine fires at all — but cannot pin the defect alone, since the setting's factory default is 60 too.
 
 ## 21. The `params float[] ratios` rect splits do not land on the far edge
 
@@ -625,4 +642,126 @@ it presents as a per-band gain the analyzer applies. Nothing reads it: `_weighte
 `UpdateSpectrum` composes each band purely from the metered amplitude and the attack/decay/smooth ballistics.
 Changing it in the inspector changes nothing about what the analyzer outputs.
 
-Status: Open, characterized. Pinned by `SpectrumAnalyzerTests.Update_BandWeighting_HasNoEffectOnTheBandOutput`.
+Status: Open, characterized. Pinned by
+`SpectrumAnalyzerTests.Update_BandWeighting_HasNoEffectOnTheBandOutput`, which drives both analyzers with a real
+440Hz tone rather than silence — on an all-zero spectrum a weight applied as a multiplier would still leave the
+two bands equal, and the pin would survive the fix it exists to catch.
+
+---
+
+## 41. `Stop(onFinished)` on a recycled handle drops the callback, silently
+
+**Where:** `Assets/BroAudio/Runtime/Player/AudioPlayerInstanceWrapper.cs:44-47`,
+`Assets/BroAudio/Runtime/Extension/Tools/InstanceWrapper.cs:8` and `:34-37`,
+`Assets/BroAudio/Runtime/Player/EmptyInstance.cs:48-51`
+
+```csharp
+void IAudioStoppable.Stop() => Instance?.Stop();
+void IAudioStoppable.Stop(Action onFinished) => Instance?.Stop(onFinished);
+void IAudioStoppable.Stop(float fadeOut) => Instance?.Stop(fadeOut);
+void IAudioStoppable.Stop(float fadeOut, Action onFinished) => Instance?.Stop(fadeOut, onFinished);
+```
+
+`InstanceWrapper.Instance` is `IsAvailable() ? _instance : null` and `Recycle()` clears `_instance`, so on a
+handle whose player has already gone back to the pool the null-conditional swallows the whole call. That is the
+right answer for the two parameterless overloads — there is nothing left to stop — but the two `Action`
+overloads carry a continuation, and it goes down with the call. `onFinished` is never stored, never queued,
+never invoked, and nothing in the signature can report it: the methods return `void`. `Empty.AudioPlayer`'s
+`Stop(Action)` is an empty body, so the handle a rejected `Play` hands back drops it identically.
+
+The canonical use of the overload is exactly what breaks:
+
+```csharp
+bgm.Stop(2f, () => SceneManager.LoadScene("Level2"));
+```
+
+If that player was recycled first — the track reached its end, a `Stop(All)` swept it, a new BGM replaced it —
+the scene never loads. Nothing distinguishes this from a fade that simply has not finished yet: no exception, no
+return value, and the stale-handle warning only appears when `RuntimeSetting.LogAccessRecycledPlayerWarning` is
+on, which is a diagnostic toggle rather than something a caller can branch on. The failure mode is a game that
+quietly stops progressing.
+
+The ordering on the live path is worth recording alongside it, because a fix has to preserve it. `StopControl`
+invokes `onFinished` at its very tail, *after* `EndPlaying()` has already recycled the player; the no-fade
+early-out invokes it *before* `EndPlaying()`. Either way the callback runs against a player that is already
+inactive or about to be, so a handler must never touch the handle it was stopped from.
+
+A wrapper that treated "already recycled" as "the work is done" could invoke `onFinished` immediately rather
+than dropping it. That would make the callback fire exactly once whether or not the caller won the race, which
+is the contract the call site is written against.
+
+Status: Open, characterized. Pinned by
+`PlaybackLifecycleTests.Stop_WithOnFinishedCallback_FiresAfterTheFadeButIsDroppedByARecycledHandle`.
+
+---
+
+## 42. `AsDominator()` after playback has started cannot re-route the player
+
+**Where:** `Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs:255-262`,
+`Assets/BroAudio/Runtime/Player/AudioPlayer.cs:40`
+
+```csharp
+private void SetupAudioTrack(IAudioPlaybackPref audioTypePref)
+{
+    if (IsDominator)
+    {
+        TrackType = AudioTrackType.Dominator;
+    }
+    AudioTrack = Mixer.GetTrack(TrackType);
+```
+
+`SetupAudioTrack` is the only place `TrackType` becomes `Dominator`, it reads `IsDominator` (i.e. whether a
+`DominatorPlayer` decorator is attached), and it runs once, at play time, when `SoundManager.LateUpdate` drains
+the queue. `AsDominator()` called after that attaches the decorator but changes nothing about routing: the
+player has already taken a generic track from the pool and stays under `Main`.
+
+That matters because a dominator's whole purpose is to duck or filter *everything else*. A dominator sitting on
+a generic track under `Main` is inside the group its own `QuietOthers`/`LowPassOthers` applies to, so it ducks
+and filters itself along with the rest. `AsDominator()` is chainable off `Play()` precisely so this does not
+happen, but nothing warns a caller who decorates a frame later.
+
+This also explains why the pre-existing `LowPassOthers_MovesDominatorLowPassParameter_*` and its HighPass twin
+never caught it: both decorate after `WaitForPlaybackStart`, and both only assert that the
+`Main_LowPass`/`Main_HighPass` parameter moved, which is true whichever track the dominator itself is on.
+
+Status: Open, characterized. Pinned by
+`SelectionStateAndDecoratorTests.Play_ThenAsDominatorAfterPlaybackStarted_StaysOnAGenericTrack`, with the
+correct same-frame routing asserted by
+`SelectionStateAndDecoratorTests.Play_AsDominatorInTheSameFrame_RoutesToADominatorTrackAndDucksTheMainTrack`.
+
+---
+
+## 43. `QuietOthers` with a zero fade time looks like it is overwritten before it takes effect
+
+**Where:** `Assets/BroAudio/Runtime/SoundManager/EffectAutomationHelper.cs:181-188`, `:199-212`, `:239-260`
+
+```csharp
+RestartCoroutine(TweakTrackParameter(tweaker, effect.Type, effect.IsDominator, onReset), ref tweaker.Coroutine);
+if (effect.IsDominator)
+{
+    SwitchMainTrackMode(true);
+}
+```
+
+`TweakTrackParameter` writes the ducked level to `Main_Dominated`, and `SwitchMainTrackMode(true)` then calls
+`ChangeChannel(Main -> Main_Dominated, FullDecibelVolume)`, which sets `Main` to `MinDecibelVolume` and
+`Main_Dominated` to **0dB**. Which of the two lands last decides whether anything ducks.
+
+With a non-zero fade time the tween yields inside its `while (currentTime < fadeTime)` loop before writing its
+final value, so `SwitchMainTrackMode(true)` runs first and the tween then ramps `Main_Dominated` down to the
+requested level. Correct.
+
+With `fadeTime` 0 the loop body never executes and `Tweak` falls straight through to
+`_mixer.SafeSetFloat(paraName, to)`. The suite already documents that a zero-fade tween drains synchronously
+inside `StartCoroutine` — that is the finding #17 regression `AudioEffectTests` guards. If that holds here, the
+ducked value is written *before* `SwitchMainTrackMode(true)` replaces it with `FullDecibelVolume`, and
+`QuietOthers(vol, 0f)` ends with `Main_Dominated` at 0dB: nothing is quieted, silently.
+
+`QuietOthers(othersVol, fadeTime)` with `fadeTime` 0 is a natural thing for a caller to write, and the reference
+docs offer no reason to avoid it.
+
+Status: **Open, suspected — derived from source, not observed.** Unity was unavailable when this was written, so
+the synchronous-drain step has not been confirmed for this path specifically. Deliberately not pinned: a test
+asserting the clobber would fail the build if the derivation is wrong. The same-frame dominator test uses a
+non-zero fade to stay clear of it. Confirming or refuting this by running
+`QuietOthers(0.2f, 0f)` and reading `Main_Dominated` is a small, worthwhile follow-up.

--- a/Docs/TEST_FINDINGS.md
+++ b/Docs/TEST_FINDINGS.md
@@ -33,6 +33,8 @@ Findings 1-7, 15-20, 28, 30 and 33 have since been fixed and moved to
 | 41 | Playback / Stop | `Stop(onFinished)` on a recycled handle drops the callback silently | Open, characterized |
 | 42 | Decorators / Dominator | `AsDominator()` after playback started cannot re-route the player, so it filters itself | Open, characterized |
 | 43 | Decorators / Dominator | `QuietOthers` with a zero fade time is overwritten by `SwitchMainTrackMode`, so nothing ducks | Open, suspected |
+| 44 | Decorators / Dominator | A looping dominator's incoming player takes a generic track at the first seam, so it ducks itself | Open, characterized |
+| 45 | Playback / Handover | `TransferAddedEffectComponents` runs once per decorator plus once, duplicating added effects every seam | Open, suspected |
 
 ---
 
@@ -753,7 +755,9 @@ requested level. Correct.
 
 With `fadeTime` 0 the loop body never executes and `Tweak` falls straight through to
 `_mixer.SafeSetFloat(paraName, to)`. The suite already documents that a zero-fade tween drains synchronously
-inside `StartCoroutine` — that is the finding #17 regression `AudioEffectTests` guards. If that holds here, the
+inside `StartCoroutine` — `AudioEffectTests.SetEffect_WithDefaultZeroFade_ThenForSeconds_AutoResetsWithoutThrowing`
+guards it, and the bug it came from is [FIXED_ISSUES.md](FIXED_ISSUES.md) #17, that file's numbering rather than
+this one's (this file has no #17; 15-20 were fixed and moved). If that holds here, the
 ducked value is written *before* `SwitchMainTrackMode(true)` replaces it with `FullDecibelVolume`, and
 `QuietOthers(vol, 0f)` ends with `Main_Dominated` at 0dB: nothing is quieted, silently.
 
@@ -765,3 +769,84 @@ the synchronous-drain step has not been confirmed for this path specifically. De
 asserting the clobber would fail the build if the derivation is wrong. The same-frame dominator test uses a
 non-zero fade to stay clear of it. Confirming or refuting this by running
 `QuietOthers(0.2f, 0f)` and reading `Main_Dominated` is a small, worthwhile follow-up.
+
+---
+
+## 44. A looping dominator loses its Dominator track at the first handover seam
+
+**Where:** `Assets/BroAudio/Runtime/Player/AudioPlayer.Playback.cs:118`, `:229`, `:334-338`, `:365`, `:402`;
+`Assets/BroAudio/Runtime/Player/AudioPlayerInstanceWrapper.cs:144-151`
+
+```csharp
+if (!isEnd)
+{
+    double warmUpTime = SoundManager.Instance.ScheduledPlaybackWarmUpTime;
+    while (AudioSettings.dspTime < _playbackEndDspTime - seamlessFadeOut - warmUpTime)
+    {
+        yield return null;
+    }
+}
+...
+_nextPlayer = RequestNextPlayer?.Invoke(handover);
+```
+
+Looping is player handover, and the handover is deliberately staged: the incoming player is created and
+started one warm-up time (0.1s) *before* the seam, while the decorators move only at `BeginHandover`, at the
+seam itself. `RequestNextPlayer` runs `SoundManager.ScheduleNextPlayback` → `ReceiveHandover` → `PlayInternal`
+synchronously, and `PlayControl` reaches `SetupAudioTrack` with nothing yielding before it — so
+`SetupAudioTrack` reads `IsDominator == false` on a player whose `_decorators` is still `null`, and takes a
+**generic** track from the pool.
+
+The decorator itself survives (`TransferDecorators`/`SetDecorators`), so `IsDominator` reads true again a
+warm-up time later, and the duck never lets go: `DominatorPlayer.PlayerIsPlaying()` is the decorator's own
+`IsActive`, the decorator is re-pointed at the incoming player before the outgoing one is recycled (and the
+outgoing `Recycle()` no longer sees the list, so it never recycles the decorator), and the `.While()` waitable
+in `TweakTrackParameter` never observes a false. `Main` stays at `MinDecibelVolume` and everything audible
+keeps flowing through `Main_Dominated` at the ducked level.
+
+The result is finding #42's self-ducking, arriving on its own: from the first loop seam onward the
+"dominator" plays under `Main` at the volume it imposed on everyone else. Unlike #42 the caller did nothing
+wrong — `AsDominator()` was chained onto `Play()` exactly as documented, and the handle they kept is still the
+live one. The generic track also picks up any non-dominator `BroAudio.SetEffect` filter via
+`SetupAudioTrack`'s `SetTrackEffect(audioTypePref.EffectType, Add)`, which a real dominator skips.
+
+A fix would be for `ReceiveHandover` (or `PlaybackHandoverData`) to carry the outgoing player's `TrackType`,
+or for the decorators to be transferred at handover-request time rather than at `BeginHandover`.
+
+Status: Open, characterized. Pinned by
+`SelectionStateAndDecoratorTests.Play_LoopingDominator_KeepsDuckingAcrossASeamButTheIncomingPlayerTakesAGenericTrack`,
+which asserts the decorator survives, the duck survives, and the track does not.
+
+---
+
+## 45. `TransferAddedEffectComponents` looks like it runs once per decorator, plus once
+
+**Where:** `Assets/BroAudio/Runtime/Player/AudioPlayerInstanceWrapper.cs:144-153`
+
+```csharp
+if (Instance.TransferDecorators(out var decorators))
+{
+    foreach (var decorator in decorators)
+    {
+        decorator.UpdateInstance(newInstance);
+    }
+    newInstance.SetDecorators(decorators);
+}
+
+Instance.TransferAddedEffectComponents(newInstance);
+```
+
+`AudioPlayerDecorator` *is* an `AudioPlayerInstanceWrapper`, so `decorator.UpdateInstance(newInstance)`
+re-enters this same override with its own `Instance` still pointing at the outgoing player — and runs
+`Instance.TransferAddedEffectComponents(newInstance)` itself. Then the outer call runs it once more. The
+delegate and decorator transfers are self-limiting because each nulls its source; `_addedEffects` is never
+cleared, so the incoming player would receive N+1 copies for N decorators, compounding at every subsequent
+seam.
+
+Reachable for any looping entity that has both an added filter component and a decorator — including a
+looping Music entity, where `RuntimeSetting.AlwaysPlayMusicAsBGM` attaches `MusicPlayer` automatically and
+`SetSpatial` adds a low-pass component for a spatial setting with `HasLowPassFilter`.
+
+Status: **Open, suspected — derived from source, not observed.** Unity was unavailable, and this was found
+while investigating #44 rather than by running anything. Not pinned: confirming it means counting components
+on the incoming player across a seam, which is worth doing before writing an assertion about the count.


### PR DESCRIPTION
Works through the Fix First section of the test suite audit: the tests that could not fail for the behaviour they named, the isolation leak, the silent skips, and the coverage holes for behaviour a user actually hears.

## ⚠️ Not compiled, not run

Unity was unavailable in the environment this was written in. **Nothing here has been through the Test Runner or even a compiler** — every assertion is grounded in production source read line by line, but that is not the same as passing. Expect at least one round of correction against real engine behaviour. This is the gating item before merge.

## What each commit does

| Item | Change |
|---|---|
| 1 | Per-type pitch leaked out of `VolumePitchMixerTests` into every later test — teardown restored volume but not pitch, and a leaked 0.5x doubles every later clip's duration. It only passed because that file sorts last. |
| 2 | 18 PlayMode tests `Assert.Ignore` on a non-realtime DSP clock and nothing failed, so a CI image that lost its audio device reported green with the heart of the suite never executed. New unconditional probe fails the run when the clock is off *and* the CI image is in use. |
| 3 | `Play_WithClipFadeOut_*` polled `GetVolume() < 0.5` over a window longer than the clip; the wrapper returns `0f` for a recycled instance, so it passed on playback *ending* rather than on a ramp. |
| 4 | Dominator routing was never asserted. `TrackType` only becomes `Dominator` inside `SetupAudioTrack` at play time, so the existing tests — which decorate after playback starts — leave the player on a generic track under `Main`, filtering itself. They pass either way. |
| 5 | Nothing drove an `IAudioPlayer` handle after a loop handover, though `UpdateInstance` exists for nothing else and it is all a caller of looping BGM has. |
| 6 | Findings #14 and #40 had pins that passed in both states. Both now fail the day their defect is fixed. |
| 7 | Six decisive timing windows sat under Unity's 0.333s capped hitch frame. Widened to ≥1s, and `WaitDspSeconds` — the suite's one unbounded wait — got a deadline. |
| 8 | `Stop(onFinished)` was untested, though "fade out, then load the next scene" is its canonical use. |
| 9 | Volume tests read `GetVolume()`, the *input* to the mixer write. A broken `UpdateVolume` passed all of them. |
| 10 | `AudioEffectTests` claimed `SetEffect` does not re-route live players. `SoundManager.SetPlayerEffect` does exactly that. Comment deleted, live path covered. |

## Five new production findings

Recorded in `Docs/TEST_FINDINGS.md`. Two are pinned by tests; **three are marked suspected rather than characterized** because they were derived from reading source with no Editor to confirm them.

- **#41** *(pinned)* — `Stop(onFinished)` on a recycled handle drops the callback silently. `Instance?.Stop(onFinished)` swallows the continuation, which is right for the parameterless overloads and silent data loss for the `Action` ones. The canonical scene-load never fires, with no exception and no return value to branch on.
- **#42** *(pinned)* — `AsDominator()` after playback started cannot re-route the player, so it sits inside the group its own `QuietOthers` applies to and ducks itself.
- **#44** *(pinned)* — a looping dominator loses its Dominator track at the first seam. The incoming player is started one warm-up time *before* the seam and reaches `SetupAudioTrack` before the decorators transfer, so it takes a generic track — while the duck survives. From the first loop seam a "dominator" plays under `Main` at the volume it imposed on everything else, with the caller having done nothing wrong.
- **#43** *(suspected)* — `QuietOthers` with a zero fade time looks like it is overwritten by `SwitchMainTrackMode` before it takes effect, so nothing ducks. Deliberately unpinned: a test asserting this would fail the build if the derivation is wrong.
- **#45** *(suspected)* — `TransferAddedEffectComponents` appears to run once per decorator plus once, duplicating added effects at every seam.

Finding #14 also turned out worse than written up: nothing in production ever adds a key to `_loadedEntityLastPlayedTime`, so the auto-unload path never runs at all in a real player. The tests work only because back-dating is what registers the entity.

## CI changes needing attention

- `.github/docker/Dockerfile` gains `BROAUDIO_CI_EXPECTS_AUDIO=1`, which the new probe reads. **The image tag in `test.yml` is bumped deliberately** — the workflow only builds when `docker manifest inspect` misses, so without the bump the published image would be reused and never carry the variable.
- `AudioClockProbeTests` is added to `required-test-suites.json`.

## Cost

PlayMode gets slower: roughly +3.5s in `FadeAndTrimTests` from lengthened clips, ~13s for the new Addressables pin (it has to outlast two cleanup ticks by design), plus the new dominator and handover tests. Two more tests now gate on `RequireRealtimeAudioClock`, which is only safe because item 2 makes that skip fail loudly on CI.

## Review notes

Three separate regressions of the same shape were caught and fixed during the work: a test made *non-vacuous* by asserting on a DSP-driven value becomes clock-dependent, and fails on a developer machine with no audio device instead of skipping. If you add assertions in this area, check which clock you are reading.

Comments in these files carry arithmetic (ease crossing points, hitch-frame margins). Several were found stale — correct when written, wrong once the fade they described was lengthened. Worth a sceptical eye on any number in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GHUh7FaKNWinrdJmeHhSWU

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHUh7FaKNWinrdJmeHhSWU)_